### PR TITLE
Feature/delivery/#24 delivery crud

### DIFF
--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/application/dto/CreateDeliveryRequest.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/application/dto/CreateDeliveryRequest.java
@@ -1,0 +1,34 @@
+package com.luckylogistics.delivery.application.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.util.UUID;
+
+/**
+ * 배송 생성 요청 DTO
+ */
+public record CreateDeliveryRequest(
+        @NotNull(message = "주문 ID는 필수입니다")
+        UUID orderId,
+
+        @NotNull(message = "출발 허브 ID는 필수입니다")
+        UUID departureHubId,
+
+        @NotNull(message = "도착 허브 ID는 필수입니다")
+        UUID arrivalHubId,
+
+        @NotBlank(message = "배송지 주소는 필수입니다")
+        @Size(max = 500, message = "배송지 주소는 500자 이하여야 합니다")
+        String deliveryAddress,
+
+        @NotBlank(message = "수령인 이름은 필수입니다")
+        @Size(max = 100, message = "수령인 이름은 100자 이하여야 합니다")
+        String recipientName,
+
+        @NotBlank(message = "수령인 슬랙 ID는 필수입니다")
+        @Email(message = "올바른 이메일 형식의 Slack ID가 아닙니다.")
+        String recipientSlackId
+) {}

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/application/dto/CreateDeliveryResponse.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/application/dto/CreateDeliveryResponse.java
@@ -1,7 +1,6 @@
 package com.luckylogistics.delivery.application.dto;
 
 import com.luckylogistics.delivery.domain.model.Delivery;
-import com.luckylogistics.delivery.domain.model.DeliveryRoute;
 import com.luckylogistics.delivery.domain.model.DeliveryStatus;
 import lombok.Builder;
 
@@ -27,7 +26,7 @@ public record CreateDeliveryResponse(
         LocalDateTime createdAt,
         List<DeliveryRouteResponse> routes
 ) {
-    public static CreateDeliveryResponse from(Delivery delivery, List<DeliveryRoute> routes) {
+    public static CreateDeliveryResponse from(Delivery delivery) {
         return CreateDeliveryResponse.builder()
                 .deliveryId(delivery.getDeliveryId())
                 .orderId(delivery.getOrderId())
@@ -39,7 +38,7 @@ public record CreateDeliveryResponse(
                 .recipientSlackId(delivery.getRecipient().getSlackId())
                 .companyDeliveryManagerId(delivery.getCompanyDeliveryManager().getDeliveryManagerId())
                 .createdAt(delivery.getCreatedAt())
-                .routes(routes.stream()
+                .routes(delivery.getRoutes().stream()
                         .map(DeliveryRouteResponse::from)
                         .collect(Collectors.toList()))
                 .build();

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/application/dto/CreateDeliveryResponse.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/application/dto/CreateDeliveryResponse.java
@@ -25,8 +25,8 @@ public record CreateDeliveryResponse(
         String recipientName,
         String recipientSlackId,
         Long companyDeliveryManagerId,
-        LocalTime companyManagerStartTime,
-        LocalTime companyManagerEndTime,
+        LocalTime deliveryManagerStartTime,
+        LocalTime deliveryManagerEndTime,
         LocalDateTime createdAt,
         List<DeliveryRouteResponse> routes
 ) {
@@ -41,8 +41,8 @@ public record CreateDeliveryResponse(
                 .recipientName(delivery.getRecipient().getName())
                 .recipientSlackId(delivery.getRecipient().getSlackId())
                 .companyDeliveryManagerId(delivery.getCompanyDeliveryManager().getDeliveryManagerId())
-                .companyManagerStartTime(delivery.getCompanyDeliveryManager().getStartTime())
-                .companyManagerEndTime(delivery.getCompanyDeliveryManager().getEndTime())
+                .deliveryManagerStartTime(delivery.getCompanyDeliveryManager().getStartTime())
+                .deliveryManagerEndTime(delivery.getCompanyDeliveryManager().getEndTime())
                 .createdAt(delivery.getCreatedAt())
                 .routes(delivery.getRoutes().stream()
                         .map(DeliveryRouteResponse::from)
@@ -65,8 +65,8 @@ public record CreateDeliveryResponse(
                 .recipientName(delivery.getRecipient().getName())
                 .recipientSlackId(delivery.getRecipient().getSlackId())
                 .companyDeliveryManagerId(companyManager.getDeliveryManagerId())
-                .companyManagerStartTime(companyManager.getStartTime())
-                .companyManagerEndTime(companyManager.getEndTime())
+                .deliveryManagerStartTime(companyManager.getStartTime())
+                .deliveryManagerEndTime(companyManager.getEndTime())
                 .createdAt(delivery.getCreatedAt())
                 .routes(routes.stream()
                         .map(DeliveryRouteResponse::from)

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/application/dto/CreateDeliveryResponse.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/application/dto/CreateDeliveryResponse.java
@@ -1,13 +1,15 @@
 package com.luckylogistics.delivery.application.dto;
 
 import com.luckylogistics.delivery.domain.model.Delivery;
+import com.luckylogistics.delivery.domain.model.DeliveryManager;
+import com.luckylogistics.delivery.domain.model.DeliveryRoute;
 import com.luckylogistics.delivery.domain.model.DeliveryStatus;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 /**
  * 배송 생성 응답 DTO
@@ -23,6 +25,8 @@ public record CreateDeliveryResponse(
         String recipientName,
         String recipientSlackId,
         Long companyDeliveryManagerId,
+        LocalTime companyManagerStartTime,
+        LocalTime companyManagerEndTime,
         LocalDateTime createdAt,
         List<DeliveryRouteResponse> routes
 ) {
@@ -37,10 +41,36 @@ public record CreateDeliveryResponse(
                 .recipientName(delivery.getRecipient().getName())
                 .recipientSlackId(delivery.getRecipient().getSlackId())
                 .companyDeliveryManagerId(delivery.getCompanyDeliveryManager().getDeliveryManagerId())
+                .companyManagerStartTime(delivery.getCompanyDeliveryManager().getStartTime())
+                .companyManagerEndTime(delivery.getCompanyDeliveryManager().getEndTime())
                 .createdAt(delivery.getCreatedAt())
                 .routes(delivery.getRoutes().stream()
                         .map(DeliveryRouteResponse::from)
-                        .collect(Collectors.toList()))
+                        .toList())
+                .build();
+    }
+
+    public static CreateDeliveryResponse of(
+            Delivery delivery,
+            DeliveryManager companyManager,
+            List<DeliveryRoute> routes
+    ) {
+        return CreateDeliveryResponse.builder()
+                .deliveryId(delivery.getDeliveryId())
+                .orderId(delivery.getOrderId())
+                .status(delivery.getStatus())
+                .departureHubId(delivery.getDepartureHubId())
+                .arrivalHubId(delivery.getArrivalHubId())
+                .deliveryAddress(delivery.getDeliveryAddress().getDeliveryAddress())
+                .recipientName(delivery.getRecipient().getName())
+                .recipientSlackId(delivery.getRecipient().getSlackId())
+                .companyDeliveryManagerId(companyManager.getDeliveryManagerId())
+                .companyManagerStartTime(companyManager.getStartTime())
+                .companyManagerEndTime(companyManager.getEndTime())
+                .createdAt(delivery.getCreatedAt())
+                .routes(routes.stream()
+                        .map(DeliveryRouteResponse::from)
+                        .toList())
                 .build();
     }
 }

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/application/dto/CreateDeliveryResponse.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/application/dto/CreateDeliveryResponse.java
@@ -1,0 +1,47 @@
+package com.luckylogistics.delivery.application.dto;
+
+import com.luckylogistics.delivery.domain.model.Delivery;
+import com.luckylogistics.delivery.domain.model.DeliveryRoute;
+import com.luckylogistics.delivery.domain.model.DeliveryStatus;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+/**
+ * 배송 생성 응답 DTO
+ */
+@Builder
+public record CreateDeliveryResponse(
+        UUID deliveryId,
+        UUID orderId,
+        DeliveryStatus status,
+        UUID departureHubId,
+        UUID arrivalHubId,
+        String deliveryAddress,
+        String recipientName,
+        String recipientSlackId,
+        Long companyDeliveryManagerId,
+        LocalDateTime createdAt,
+        List<DeliveryRouteResponse> routes
+) {
+    public static CreateDeliveryResponse from(Delivery delivery, List<DeliveryRoute> routes) {
+        return CreateDeliveryResponse.builder()
+                .deliveryId(delivery.getDeliveryId())
+                .orderId(delivery.getOrderId())
+                .status(delivery.getStatus())
+                .departureHubId(delivery.getDepartureHubId())
+                .arrivalHubId(delivery.getArrivalHubId())
+                .deliveryAddress(delivery.getDeliveryAddress().getDeliveryAddress())
+                .recipientName(delivery.getRecipient().getName())
+                .recipientSlackId(delivery.getRecipient().getSlackId())
+                .companyDeliveryManagerId(delivery.getCompanyDeliveryManager().getDeliveryManagerId())
+                .createdAt(delivery.getCreatedAt())
+                .routes(routes.stream()
+                        .map(DeliveryRouteResponse::from)
+                        .collect(Collectors.toList()))
+                .build();
+    }
+}

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/application/dto/DeliveryResponse.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/application/dto/DeliveryResponse.java
@@ -1,7 +1,6 @@
 package com.luckylogistics.delivery.application.dto;
 
 import com.luckylogistics.delivery.domain.model.Delivery;
-import com.luckylogistics.delivery.domain.model.DeliveryRoute;
 import com.luckylogistics.delivery.domain.model.DeliveryStatus;
 import lombok.Builder;
 
@@ -28,7 +27,7 @@ public record DeliveryResponse(
         LocalDateTime updatedAt,
         List<DeliveryRouteResponse> routes
 ) {
-    public static DeliveryResponse from(Delivery delivery, List<DeliveryRoute> routes) {
+    public static DeliveryResponse from(Delivery delivery) {
         return DeliveryResponse.builder()
                 .deliveryId(delivery.getDeliveryId())
                 .orderId(delivery.getOrderId())
@@ -41,7 +40,7 @@ public record DeliveryResponse(
                 .companyDeliveryManagerId(delivery.getCompanyDeliveryManager().getDeliveryManagerId())
                 .createdAt(delivery.getCreatedAt())
                 .updatedAt(delivery.getUpdatedAt())
-                .routes(routes.stream()
+                .routes(delivery.getRoutes().stream()
                         .map(DeliveryRouteResponse::from)
                         .collect(Collectors.toList()))
                 .build();

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/application/dto/DeliveryResponse.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/application/dto/DeliveryResponse.java
@@ -23,8 +23,8 @@ public record DeliveryResponse(
         String recipientName,
         String recipientSlackId,
         Long companyDeliveryManagerId,
-        LocalTime companyManagerStartTime,
-        LocalTime companyManagerEndTime,
+        LocalTime deliveryManagerStartTime,
+        LocalTime deliveryManagerEndTime,
         LocalDateTime createdAt,
         LocalDateTime updatedAt,
         List<DeliveryRouteResponse> routes
@@ -40,8 +40,8 @@ public record DeliveryResponse(
                 .recipientName(delivery.getRecipient().getName())
                 .recipientSlackId(delivery.getRecipient().getSlackId())
                 .companyDeliveryManagerId(delivery.getCompanyDeliveryManager().getDeliveryManagerId())
-                .companyManagerStartTime(delivery.getCompanyDeliveryManager().getStartTime())
-                .companyManagerEndTime(delivery.getCompanyDeliveryManager().getEndTime())
+                .deliveryManagerStartTime(delivery.getCompanyDeliveryManager().getStartTime())
+                .deliveryManagerEndTime(delivery.getCompanyDeliveryManager().getEndTime())
                 .createdAt(delivery.getCreatedAt())
                 .updatedAt(delivery.getUpdatedAt())
                 .routes(delivery.getRoutes().stream()

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/application/dto/DeliveryResponse.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/application/dto/DeliveryResponse.java
@@ -1,0 +1,49 @@
+package com.luckylogistics.delivery.application.dto;
+
+import com.luckylogistics.delivery.domain.model.Delivery;
+import com.luckylogistics.delivery.domain.model.DeliveryRoute;
+import com.luckylogistics.delivery.domain.model.DeliveryStatus;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+/**
+ * 배송 응답 DTO
+ */
+@Builder
+public record DeliveryResponse(
+        UUID deliveryId,
+        UUID orderId,
+        DeliveryStatus status,
+        UUID departureHubId,
+        UUID arrivalHubId,
+        String deliveryAddress,
+        String recipientName,
+        String recipientSlackId,
+        Long companyDeliveryManagerId,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt,
+        List<DeliveryRouteResponse> routes
+) {
+    public static DeliveryResponse from(Delivery delivery, List<DeliveryRoute> routes) {
+        return DeliveryResponse.builder()
+                .deliveryId(delivery.getDeliveryId())
+                .orderId(delivery.getOrderId())
+                .status(delivery.getStatus())
+                .departureHubId(delivery.getDepartureHubId())
+                .arrivalHubId(delivery.getArrivalHubId())
+                .deliveryAddress(delivery.getDeliveryAddress().getDeliveryAddress())
+                .recipientName(delivery.getRecipient().getName())
+                .recipientSlackId(delivery.getRecipient().getSlackId())
+                .companyDeliveryManagerId(delivery.getCompanyDeliveryManager().getDeliveryManagerId())
+                .createdAt(delivery.getCreatedAt())
+                .updatedAt(delivery.getUpdatedAt())
+                .routes(routes.stream()
+                        .map(DeliveryRouteResponse::from)
+                        .collect(Collectors.toList()))
+                .build();
+    }
+}

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/application/dto/DeliveryResponse.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/application/dto/DeliveryResponse.java
@@ -24,8 +24,8 @@ public record DeliveryResponse(
         String recipientName,
         String recipientSlackId,
         Long companyDeliveryManagerId,
-        LocalTime workStartTime,
-        LocalTime workEndTime,
+        LocalTime companyManagerStartTime,
+        LocalTime companyManagerEndTime,
         LocalDateTime createdAt,
         LocalDateTime updatedAt,
         List<DeliveryRouteResponse> routes
@@ -41,8 +41,8 @@ public record DeliveryResponse(
                 .recipientName(delivery.getRecipient().getName())
                 .recipientSlackId(delivery.getRecipient().getSlackId())
                 .companyDeliveryManagerId(delivery.getCompanyDeliveryManager().getDeliveryManagerId())
-                .workStartTime(delivery.getCompanyDeliveryManager().getStartTime())
-                .workEndTime(delivery.getCompanyDeliveryManager().getEndTime())
+                .companyManagerStartTime(delivery.getCompanyDeliveryManager().getStartTime())
+                .companyManagerEndTime(delivery.getCompanyDeliveryManager().getEndTime())
                 .createdAt(delivery.getCreatedAt())
                 .updatedAt(delivery.getUpdatedAt())
                 .routes(delivery.getRoutes().stream()

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/application/dto/DeliveryResponse.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/application/dto/DeliveryResponse.java
@@ -5,6 +5,7 @@ import com.luckylogistics.delivery.domain.model.DeliveryStatus;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -23,6 +24,8 @@ public record DeliveryResponse(
         String recipientName,
         String recipientSlackId,
         Long companyDeliveryManagerId,
+        LocalTime workStartTime,
+        LocalTime workEndTime,
         LocalDateTime createdAt,
         LocalDateTime updatedAt,
         List<DeliveryRouteResponse> routes
@@ -38,6 +41,8 @@ public record DeliveryResponse(
                 .recipientName(delivery.getRecipient().getName())
                 .recipientSlackId(delivery.getRecipient().getSlackId())
                 .companyDeliveryManagerId(delivery.getCompanyDeliveryManager().getDeliveryManagerId())
+                .workStartTime(delivery.getCompanyDeliveryManager().getStartTime())
+                .workEndTime(delivery.getCompanyDeliveryManager().getEndTime())
                 .createdAt(delivery.getCreatedAt())
                 .updatedAt(delivery.getUpdatedAt())
                 .routes(delivery.getRoutes().stream()

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/application/dto/DeliveryResponse.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/application/dto/DeliveryResponse.java
@@ -8,10 +8,9 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 /**
- * 배송 응답 DTO
+ * 배송 조회 응답 DTO
  */
 @Builder
 public record DeliveryResponse(
@@ -47,7 +46,7 @@ public record DeliveryResponse(
                 .updatedAt(delivery.getUpdatedAt())
                 .routes(delivery.getRoutes().stream()
                         .map(DeliveryRouteResponse::from)
-                        .collect(Collectors.toList()))
+                        .toList())
                 .build();
     }
 }

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/application/dto/DeliveryRoutePlan.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/application/dto/DeliveryRoutePlan.java
@@ -1,0 +1,33 @@
+package com.luckylogistics.delivery.application.dto;
+
+import lombok.Builder;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+/**
+ * 배송 경로 응답 DTO
+ */
+@Builder
+public record DeliveryRoutePlan(
+        List<DeliveryRouteSegment> routes,
+        BigDecimal totalDistance,
+        Integer totalDuration
+) {
+    public DeliveryRoutePlan {
+        routes = routes == null ? List.of() : List.copyOf(routes);
+    }
+
+    public static DeliveryRoutePlan of(
+            List<DeliveryRouteSegment> routes,
+            BigDecimal totalDistance,
+            Integer totalDuration
+    ) {
+
+        return DeliveryRoutePlan.builder()
+                .routes(routes)
+                .totalDistance(totalDistance)
+                .totalDuration(totalDuration)
+                .build();
+    }
+}

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/application/dto/DeliveryRouteResponse.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/application/dto/DeliveryRouteResponse.java
@@ -1,0 +1,44 @@
+package com.luckylogistics.delivery.application.dto;
+
+import com.luckylogistics.delivery.domain.model.DeliveryRoute;
+import com.luckylogistics.delivery.domain.model.DeliveryRouteStatus;
+import lombok.Builder;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Builder
+public record DeliveryRouteResponse(
+        UUID deliveryRouteId,
+        UUID deliveryId,
+        Integer sequence,
+        UUID departureHubId,
+        UUID arrivalHubId,
+        BigDecimal estimatedDistance,
+        Integer estimatedDuration,
+        BigDecimal actualDistance,
+        Integer actualDuration,
+        DeliveryRouteStatus status,
+        Long hubDeliveryManagerId,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+    public static DeliveryRouteResponse from(DeliveryRoute route) {
+        return DeliveryRouteResponse.builder()
+                .deliveryRouteId(route.getDeliveryRouteId())
+                .deliveryId(route.getDelivery().getDeliveryId())
+                .sequence(route.getSequence())
+                .departureHubId(route.getDepartureHubId())
+                .arrivalHubId(route.getArrivalHubId())
+                .estimatedDistance(route.getEstimatedDistance())
+                .estimatedDuration(route.getEstimatedDuration())
+                .actualDistance(route.getActualDistance())
+                .actualDuration(route.getActualDuration())
+                .status(route.getStatus())
+                .hubDeliveryManagerId(route.getHubDeliveryManager().getDeliveryManagerId())
+                .createdAt(route.getCreatedAt())
+                .updatedAt(route.getUpdatedAt())
+                .build();
+    }
+}

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/application/dto/DeliveryRouteResponse.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/application/dto/DeliveryRouteResponse.java
@@ -27,7 +27,7 @@ public record DeliveryRouteResponse(
     public static DeliveryRouteResponse from(DeliveryRoute route) {
         return DeliveryRouteResponse.builder()
                 .deliveryRouteId(route.getDeliveryRouteId())
-                .deliveryId(route.getDelivery().getDeliveryId())
+                .deliveryId(route.getDeliveryId())
                 .sequence(route.getSequence())
                 .departureHubId(route.getDepartureHubId())
                 .arrivalHubId(route.getArrivalHubId())

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/application/dto/DeliveryRouteSegment.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/application/dto/DeliveryRouteSegment.java
@@ -1,0 +1,32 @@
+package com.luckylogistics.delivery.application.dto;
+
+import lombok.Builder;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+@Builder
+public record DeliveryRouteSegment(
+        Integer sequence,
+        UUID departureHubId,
+        UUID arrivalHubId,
+        BigDecimal distanceKm,
+        Integer durationMinutes
+) {
+    public static DeliveryRouteSegment of(
+            int sequence,
+            UUID departureHubId,
+            UUID arrivalHubId,
+            BigDecimal distanceKm,
+            int durationMinutes
+    ) {
+
+        return DeliveryRouteSegment.builder()
+                .sequence(sequence)
+                .departureHubId(departureHubId)
+                .arrivalHubId(arrivalHubId)
+                .distanceKm(distanceKm)
+                .durationMinutes(durationMinutes)
+                .build();
+    }
+}

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/application/dto/DeliverySummaryResponse.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/application/dto/DeliverySummaryResponse.java
@@ -1,0 +1,42 @@
+package com.luckylogistics.delivery.application.dto;
+
+import com.luckylogistics.delivery.domain.model.Delivery;
+import com.luckylogistics.delivery.domain.model.DeliveryStatus;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * 배송 목록 응답 DTO
+ */
+@Builder
+public record DeliverySummaryResponse(
+        UUID deliveryId,
+        UUID orderId,
+        DeliveryStatus status,
+        UUID departureHubId,
+        UUID arrivalHubId,
+        String deliveryAddress,
+        String recipientName,
+        String recipientSlackId,
+        Long companyDeliveryManagerId,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+    public static DeliverySummaryResponse from(Delivery delivery) {
+        return DeliverySummaryResponse.builder()
+                .deliveryId(delivery.getDeliveryId())
+                .orderId(delivery.getOrderId())
+                .status(delivery.getStatus())
+                .departureHubId(delivery.getDepartureHubId())
+                .arrivalHubId(delivery.getArrivalHubId())
+                .deliveryAddress(delivery.getDeliveryAddress().getDeliveryAddress())
+                .recipientName(delivery.getRecipient().getName())
+                .recipientSlackId(delivery.getRecipient().getSlackId())
+                .companyDeliveryManagerId(delivery.getCompanyDeliveryManager().getDeliveryManagerId())
+                .createdAt(delivery.getCreatedAt())
+                .updatedAt(delivery.getUpdatedAt())
+                .build();
+    }
+}

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/application/dto/UpdateDeliveryResponse.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/application/dto/UpdateDeliveryResponse.java
@@ -1,0 +1,42 @@
+package com.luckylogistics.delivery.application.dto;
+
+import com.luckylogistics.delivery.domain.model.Delivery;
+import com.luckylogistics.delivery.domain.model.DeliveryStatus;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * 배송 수정 응답 DTO
+ */
+@Builder
+public record UpdateDeliveryResponse(
+        UUID deliveryId,
+        UUID orderId,
+        DeliveryStatus status,
+        UUID departureHubId,
+        UUID arrivalHubId,
+        String deliveryAddress,
+        String recipientName,
+        String recipientSlackId,
+        Long companyDeliveryManagerId,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+    public static UpdateDeliveryResponse from(Delivery delivery) {
+        return UpdateDeliveryResponse.builder()
+                .deliveryId(delivery.getDeliveryId())
+                .orderId(delivery.getOrderId())
+                .status(delivery.getStatus())
+                .departureHubId(delivery.getDepartureHubId())
+                .arrivalHubId(delivery.getArrivalHubId())
+                .deliveryAddress(delivery.getDeliveryAddress().getDeliveryAddress())
+                .recipientName(delivery.getRecipient().getName())
+                .recipientSlackId(delivery.getRecipient().getSlackId())
+                .companyDeliveryManagerId(delivery.getCompanyDeliveryManager().getDeliveryManagerId())
+                .createdAt(delivery.getCreatedAt())
+                .updatedAt(delivery.getUpdatedAt())
+                .build();
+    }
+}

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/application/dto/UpdateDeliveryStatusRequest.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/application/dto/UpdateDeliveryStatusRequest.java
@@ -1,0 +1,9 @@
+package com.luckylogistics.delivery.application.dto;
+
+import com.luckylogistics.delivery.domain.model.DeliveryStatus;
+import jakarta.validation.constraints.NotNull;
+
+public record UpdateDeliveryStatusRequest(
+        @NotNull(message = "변경할 상태는 필수입니다")
+        DeliveryStatus status
+) {}

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/application/service/DeliveryService.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/application/service/DeliveryService.java
@@ -199,7 +199,7 @@ public class DeliveryService {
         Delivery delivery = findDeliveryByIdWithRoutes(deliveryId);
         validateDeletePermission(delivery, currentUserId, currentUserRole);
 
-        delivery.delete(currentUserId);
+        delivery.deleteCascade(currentUserId);
 
         log.info("[Delivery] 배송 삭제 완료. deliveryId: {}", deliveryId);
     }

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/application/service/DeliveryService.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/application/service/DeliveryService.java
@@ -1,0 +1,90 @@
+package com.luckylogistics.delivery.application.service;
+
+import com.luckylogistics.delivery.application.dto.CreateDeliveryRequest;
+import com.luckylogistics.delivery.application.dto.CreateDeliveryResponse;
+import com.luckylogistics.delivery.application.dto.DeliveryRoutePlan;
+import com.luckylogistics.delivery.application.dto.DeliveryRouteSegment;
+import com.luckylogistics.delivery.common.exception.BusinessException;
+import com.luckylogistics.delivery.common.exception.ErrorCode;
+import com.luckylogistics.delivery.domain.model.*;
+import com.luckylogistics.delivery.domain.repository.DeliveryRepository;
+import com.luckylogistics.delivery.domain.repository.DeliveryRouteRepository;
+import com.luckylogistics.delivery.domain.service.DeliveryDomainService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * 배송 서비스
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class DeliveryService {
+
+    private final DeliveryRepository deliveryRepository;
+    private final DeliveryRouteRepository deliveryRouteRepository;
+    private final DeliveryDomainService domainService;
+
+    private final HubService hubService;
+    private final OrderService orderService;
+
+    /**
+     * 배송 생성
+     */
+    @Transactional
+    public CreateDeliveryResponse createDelivery(CreateDeliveryRequest request, Long currentUserId) {
+        log.info("[Delivery] 배송 생성 시작. orderId: {}", request.orderId());
+
+        if (deliveryRepository.existsByOrderId(request.orderId())) {
+            throw new BusinessException(ErrorCode.DUPLICATE_DELIVERY);
+        }
+
+        orderService.validateOrderExists(request.orderId());
+        hubService.validateHubExists(request.departureHubId());
+        hubService.validateHubExists(request.arrivalHubId());
+
+        DeliveryRoutePlan deliveryRoutePlan = hubService.getDeliveryRoutePlan(
+                request.departureHubId(), request.arrivalHubId()
+        );
+
+        DeliveryManager companyManager = domainService.assignCompanyDeliveryManager(request.arrivalHubId());
+
+        Delivery delivery = Delivery.create(
+                request.orderId(),
+                request.departureHubId(),
+                request.arrivalHubId(),
+                DeliveryAddress.of(request.deliveryAddress()),
+                Recipient.of(request.recipientName(), request.recipientSlackId()),
+                companyManager
+        );
+
+        Delivery savedDelivery = deliveryRepository.save(delivery);
+
+        for (DeliveryRouteSegment routeSegment : deliveryRoutePlan.routes()) {
+            DeliveryManager hubManager = domainService.assignHubDeliveryManager();
+
+            DeliveryRoute route = DeliveryRoute.create(
+                    savedDelivery,
+                    routeSegment.sequence(),
+                    routeSegment.departureHubId(),
+                    routeSegment.arrivalHubId(),
+                    routeSegment.distanceKm(),
+                    routeSegment.durationMinutes(),
+                    hubManager
+            );
+
+            deliveryRouteRepository.save(route);
+        }
+
+        List<DeliveryRoute> routes = deliveryRouteRepository.findByDeliveryIdOrderBySequence(savedDelivery.getDeliveryId());
+
+        log.info("[Delivery] 배송 생성 완료. deliveryId: {}, routes: {}", savedDelivery.getDeliveryId(), routes.size());
+
+        return CreateDeliveryResponse.from(savedDelivery, routes);
+    }
+}

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/application/service/DeliveryService.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/application/service/DeliveryService.java
@@ -254,25 +254,38 @@ public class DeliveryService {
             UserRole currentUserRole,
             Pageable pageable
     ) {
-        if (currentUserRole == null) throw new BusinessException(ErrorCode.FORBIDDEN_DELIVERY_READ);
+        if (currentUserRole == null) {
+            throw new BusinessException(ErrorCode.FORBIDDEN_DELIVERY_SEARCH);
+        }
 
-        // 허브 관리자: 담당 허브 배송 내역 조회
+        if (currentUserId == null) {
+            throw new BusinessException(ErrorCode.FORBIDDEN_DELIVERY_SEARCH);
+        }
+
+        // 마스터 / 업체 관리자: 전체 조회 권한 + 필터
+        if (currentUserRole.isMaster() || currentUserRole.isCompanyManager()) {
+            return deliveryRepository.searchDeliveries(
+                    status, departureHubId, arrivalHubId, pageable);
+        }
+
+        // 허브 관리자: 배송 경로에 내 허브가 포함된 배송만 조회 + 필터
         if (currentUserRole.isHubManager()) {
             UUID userHubId = hubService.getUserHubId(currentUserId);
-            return deliveryRepository.searchByHubId(userHubId, pageable);
+            if (userHubId == null) {
+                throw new BusinessException(ErrorCode.FORBIDDEN_DELIVERY_SEARCH);
+            }
+            // 출발/도착/경유 허브 모두 확인
+            return deliveryRepository.searchByHubIdIncludingRoutes(
+                    userHubId, status, departureHubId, arrivalHubId, pageable);
         }
 
-        // 배송 관리자: 업체 배송 담당자 / 허브 배송 담당자
+        // 3. 배송 담당자: 내가 담당한 배송만 조회 + 필터
         if (currentUserRole.isDeliveryManager()) {
-            // 먼저 업체 배송 담당자로 조회
-            Page<Delivery> companyDeliveries = deliveryRepository
-                    .searchByCompanyDeliveryManagerUserId(currentUserId, pageable);
-            if (companyDeliveries.hasContent()) {
-                return companyDeliveries;
-            }
-            // 없으면 허브 배송 담당자로 조회
-            return deliveryRepository.searchByHubDeliveryManagerUserId(currentUserId, pageable);
+            // 업체 배송 담당자 / 허브 배송 담당자 통합 조회
+            return deliveryRepository.searchByDeliveryManagerUserId(
+                    currentUserId, status, departureHubId, arrivalHubId, pageable);
         }
-        return deliveryRepository.searchDeliveries(status, departureHubId, arrivalHubId, pageable);
+
+        throw new BusinessException(ErrorCode.FORBIDDEN_DELIVERY_SEARCH);
     }
 }

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/application/service/DeliveryService.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/application/service/DeliveryService.java
@@ -105,6 +105,11 @@ public class DeliveryService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.DELIVERY_NOT_FOUND));
     }
 
+    private Delivery findDeliveryByIdWithCompanyManager(UUID id) {
+        return deliveryRepository.findByIdWithCompanyManager(id)
+                .orElseThrow(() -> new BusinessException(ErrorCode.DELIVERY_NOT_FOUND));
+    }
+
     private Delivery findDeliveryByIdWithRoutes(UUID id) {
         return deliveryRepository.findByIdWithRoutes(id)
                 .orElseThrow(() -> new BusinessException(ErrorCode.DELIVERY_NOT_FOUND));
@@ -153,7 +158,7 @@ public class DeliveryService {
         log.info("[Delivery] 배송 상태 변경. deliveryId: {}, newStatus: {}", deliveryId, request.status());
 
         // 배송 조회
-        Delivery delivery = findDeliveryById(deliveryId);
+        Delivery delivery = findDeliveryByIdWithCompanyManager(deliveryId);
         // 권한 검증 (마스터/해당 허브관리자/업체배송담당자)
         validateStatusChangePermission(delivery, currentUserId, currentUserRole);
         // 상태 변경

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/application/service/DeliveryService.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/application/service/DeliveryService.java
@@ -4,11 +4,15 @@ import com.luckylogistics.delivery.application.dto.*;
 import com.luckylogistics.delivery.common.enums.UserRole;
 import com.luckylogistics.delivery.common.exception.BusinessException;
 import com.luckylogistics.delivery.common.exception.ErrorCode;
+import com.luckylogistics.delivery.common.util.PageableUtils;
 import com.luckylogistics.delivery.domain.model.*;
 import com.luckylogistics.delivery.domain.repository.DeliveryRepository;
 import com.luckylogistics.delivery.domain.service.DeliveryDomainService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -222,5 +226,53 @@ public class DeliveryService {
         }
         // 업체 담당자, 배송 담당자: 삭제 불가
         throw new BusinessException(ErrorCode.FORBIDDEN_DELIVERY_DELETE);
+    }
+
+    public Page<DeliverySummaryResponse> getDeliveries(
+            DeliveryStatus status,
+            UUID departureHubId,
+            UUID arrivalHubId,
+            int page,
+            int size,
+            String sortBy,
+            Sort.Direction direction,
+            Long currentUserId,
+            UserRole currentUserRole
+    ) {
+        Pageable pageable = PageableUtils.createPageable(page, size, sortBy, direction);
+        Page<Delivery> deliveries = findDeliveries(
+                status, departureHubId, arrivalHubId, currentUserId, currentUserRole, pageable);
+
+        return deliveries.map(DeliverySummaryResponse::from);
+    }
+
+    private Page<Delivery> findDeliveries(
+            DeliveryStatus status,
+            UUID departureHubId,
+            UUID arrivalHubId,
+            Long currentUserId,
+            UserRole currentUserRole,
+            Pageable pageable
+    ) {
+        if (currentUserRole == null) throw new BusinessException(ErrorCode.FORBIDDEN_DELIVERY_READ);
+
+        // 허브 관리자: 담당 허브 배송 내역 조회
+        if (currentUserRole.isHubManager()) {
+            UUID userHubId = hubService.getUserHubId(currentUserId);
+            return deliveryRepository.searchByHubId(userHubId, pageable);
+        }
+
+        // 배송 관리자: 업체 배송 담당자 / 허브 배송 담당자
+        if (currentUserRole.isDeliveryManager()) {
+            // 먼저 업체 배송 담당자로 조회
+            Page<Delivery> companyDeliveries = deliveryRepository
+                    .searchByCompanyDeliveryManagerUserId(currentUserId, pageable);
+            if (companyDeliveries.hasContent()) {
+                return companyDeliveries;
+            }
+            // 없으면 허브 배송 담당자로 조회
+            return deliveryRepository.searchByHubDeliveryManagerUserId(currentUserId, pageable);
+        }
+        return deliveryRepository.searchDeliveries(status, departureHubId, arrivalHubId, pageable);
     }
 }

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/application/service/DeliveryService.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/application/service/DeliveryService.java
@@ -1,9 +1,7 @@
 package com.luckylogistics.delivery.application.service;
 
-import com.luckylogistics.delivery.application.dto.CreateDeliveryRequest;
-import com.luckylogistics.delivery.application.dto.CreateDeliveryResponse;
-import com.luckylogistics.delivery.application.dto.DeliveryRoutePlan;
-import com.luckylogistics.delivery.application.dto.DeliveryRouteSegment;
+import com.luckylogistics.delivery.application.dto.*;
+import com.luckylogistics.delivery.common.enums.UserRole;
 import com.luckylogistics.delivery.common.exception.BusinessException;
 import com.luckylogistics.delivery.common.exception.ErrorCode;
 import com.luckylogistics.delivery.domain.model.*;
@@ -16,6 +14,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.UUID;
 
 /**
  * 배송 서비스
@@ -86,5 +85,42 @@ public class DeliveryService {
         log.info("[Delivery] 배송 생성 완료. deliveryId: {}, routes: {}", savedDelivery.getDeliveryId(), routes.size());
 
         return CreateDeliveryResponse.from(savedDelivery, routes);
+    }
+
+    public DeliveryResponse getDelivery(UUID deliveryId, Long currentUserId, UserRole currentUserRole) {
+        Delivery delivery = findDeliveryById(deliveryId);
+        validateReadPermission(delivery, currentUserId, currentUserRole);
+
+        List<DeliveryRoute> routes = deliveryRouteRepository.findByDeliveryIdOrderBySequence(deliveryId);
+
+        return DeliveryResponse.from(delivery, routes);
+    }
+
+    private Delivery findDeliveryById(UUID id) {
+        return deliveryRepository.findById(id)
+                .orElseThrow(() -> new BusinessException(ErrorCode.DELIVERY_NOT_FOUND));
+    }
+
+    private void validateReadPermission(Delivery delivery, Long currentUserId, UserRole currentUserRole) {
+        if (currentUserRole.isMaster() || currentUserRole.isCompanyManager()) {
+            return;
+        }
+
+        if (currentUserRole.isHubManager()) {
+            UUID userHubId = hubService.getUserHubId(currentUserId);
+            if (!delivery.isRelatedToHub(userHubId)) {
+                throw new BusinessException(ErrorCode.FORBIDDEN_DELIVERY_READ);
+            }
+            return;
+        }
+
+        if (currentUserRole.isDeliveryManager()) {
+            if (!delivery.isAssignedTo(currentUserId)) {
+                throw new BusinessException(ErrorCode.FORBIDDEN_DELIVERY_READ);
+            }
+            return;
+        }
+
+        throw new BusinessException(ErrorCode.FORBIDDEN_DELIVERY_READ);
     }
 }

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/application/service/DeliveryService.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/application/service/DeliveryService.java
@@ -2,10 +2,6 @@ package com.luckylogistics.delivery.application.service;
 
 import com.luckylogistics.delivery.application.dto.*;
 import com.luckylogistics.delivery.common.enums.UserRole;
-import com.luckylogistics.delivery.application.dto.CreateDeliveryRequest;
-import com.luckylogistics.delivery.application.dto.CreateDeliveryResponse;
-import com.luckylogistics.delivery.application.dto.DeliveryRoutePlan;
-import com.luckylogistics.delivery.application.dto.DeliveryRouteSegment;
 import com.luckylogistics.delivery.common.exception.BusinessException;
 import com.luckylogistics.delivery.common.exception.ErrorCode;
 import com.luckylogistics.delivery.domain.model.*;
@@ -126,5 +122,50 @@ public class DeliveryService {
         }
 
         throw new BusinessException(ErrorCode.FORBIDDEN_DELIVERY_READ);
+    }
+
+    @Transactional
+    public UpdateDeliveryResponse updateDeliveryStatus(
+            UUID deliveryId,
+            UpdateDeliveryStatusRequest request,
+            Long currentUserId,
+            UserRole currentUserRole
+    ) {
+        log.info("[Delivery] 배송 상태 변경. deliveryId: {}, newStatus: {}", deliveryId, request.status());
+
+        // 배송 조회
+        Delivery delivery = findDeliveryById(deliveryId);
+        // 권한 검증 (마스터/해당 허브관리자/업체배송담당자)
+        validateStatusChangePermission(delivery, currentUserId, currentUserRole);
+        // 상태 변경
+        delivery.changeStatus(request.status(), true);
+
+        log.info("[Delivery] 배송 상태 변경 완료. deliveryId: {}", deliveryId);
+        return UpdateDeliveryResponse.from(delivery);
+    }
+
+    private void validateStatusChangePermission(Delivery delivery, Long currentUserId, UserRole currentUserRole) {
+        // 마스터 관리자: 허용
+        if (currentUserRole.isMaster()) return;
+
+        // 회사(발주/수령) 관리자: 배송 상태 변경 불가
+        if (currentUserRole.isCompanyManager()) {
+            throw new BusinessException(ErrorCode.FORBIDDEN_DELIVERY_MODIFY);
+        }
+
+        // 허브 관리자: 도착 허브 관리자만 허용
+        if (currentUserRole.isHubManager()) {
+            UUID userHubId = hubService.getUserHubId(currentUserId);
+            if (!delivery.isArrivalHub(userHubId)) {
+                throw new BusinessException(ErrorCode.FORBIDDEN_DELIVERY_MODIFY);
+            }
+        }
+
+        // 배송 담당자: 본인에게 할당된 배송만 상태 변경 가능
+        if (currentUserRole.isDeliveryManager()) {
+            if (!delivery.isAssignedTo(currentUserId)) {
+                throw new BusinessException(ErrorCode.FORBIDDEN_DELIVERY_MODIFY);
+            }
+        }
     }
 }

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/application/service/DeliveryService.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/application/service/DeliveryService.java
@@ -145,6 +145,10 @@ public class DeliveryService {
     }
 
     private void validateStatusChangePermission(Delivery delivery, Long currentUserId, UserRole currentUserRole) {
+        if (currentUserRole == null) {
+            throw new BusinessException(ErrorCode.FORBIDDEN_DELIVERY_MODIFY);
+        }
+
         // 마스터 관리자: 허용
         if (currentUserRole.isMaster()) return;
 
@@ -159,6 +163,7 @@ public class DeliveryService {
             if (!delivery.isArrivalHub(userHubId)) {
                 throw new BusinessException(ErrorCode.FORBIDDEN_DELIVERY_MODIFY);
             }
+            return;
         }
 
         // 배송 담당자: 본인에게 할당된 배송만 상태 변경 가능
@@ -166,6 +171,9 @@ public class DeliveryService {
             if (!delivery.isAssignedTo(currentUserId)) {
                 throw new BusinessException(ErrorCode.FORBIDDEN_DELIVERY_MODIFY);
             }
+            return;
         }
+
+        throw new BusinessException(ErrorCode.FORBIDDEN_DELIVERY_MODIFY);
     }
 }

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/application/service/DeliveryService.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/application/service/DeliveryService.java
@@ -6,7 +6,6 @@ import com.luckylogistics.delivery.common.exception.BusinessException;
 import com.luckylogistics.delivery.common.exception.ErrorCode;
 import com.luckylogistics.delivery.domain.model.*;
 import com.luckylogistics.delivery.domain.repository.DeliveryRepository;
-import com.luckylogistics.delivery.domain.repository.DeliveryRouteRepository;
 import com.luckylogistics.delivery.domain.service.DeliveryDomainService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -27,7 +26,6 @@ import java.util.stream.Collectors;
 public class DeliveryService {
 
     private final DeliveryRepository deliveryRepository;
-    private final DeliveryRouteRepository deliveryRouteRepository;
     private final DeliveryDomainService domainService;
 
     private final HubService hubService;
@@ -92,12 +90,10 @@ public class DeliveryService {
     }
 
     public DeliveryResponse getDelivery(UUID deliveryId, Long currentUserId, UserRole currentUserRole) {
-        Delivery delivery = findDeliveryById(deliveryId);
+        Delivery delivery = findDeliveryByIdWithRoutes(deliveryId);
         validateReadPermission(delivery, currentUserId, currentUserRole);
 
-        List<DeliveryRoute> routes = deliveryRouteRepository.findByDeliveryIdOrderBySequence(deliveryId);
-
-        return DeliveryResponse.from(delivery, routes);
+        return DeliveryResponse.from(delivery);
     }
 
     private Delivery findDeliveryById(UUID id) {
@@ -105,21 +101,36 @@ public class DeliveryService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.DELIVERY_NOT_FOUND));
     }
 
-    private void validateReadPermission(Delivery delivery, Long currentUserId, UserRole currentUserRole) {
-        if (currentUserRole.isMaster() || currentUserRole.isCompanyManager()) {
-            return;
-        }
+    private Delivery findDeliveryByIdWithRoutes(UUID id) {
+        return deliveryRepository.findByIdWithRoutes(id)
+                .orElseThrow(() -> new BusinessException(ErrorCode.DELIVERY_NOT_FOUND));
+    }
 
+    private void validateReadPermission(Delivery delivery, Long currentUserId, UserRole currentUserRole) {
+        if (currentUserRole == null) throw new BusinessException(ErrorCode.FORBIDDEN_DELIVERY_READ);
+
+        // 마스터 / 업체 관리자: 항상 허용
+        if (currentUserRole.isMaster() || currentUserRole.isCompanyManager()) return;
+
+        // 허브 관리자: 배송의 출발/도착 허브, 경로에 포함된 모든 허브 관리자는 접근 가능
         if (currentUserRole.isHubManager()) {
             UUID userHubId = hubService.getUserHubId(currentUserId);
-            if (!delivery.isRelatedToHub(userHubId)) {
-                throw new BusinessException(ErrorCode.FORBIDDEN_DELIVERY_READ);
-            }
+            boolean permitted =
+                    delivery.isRelatedToHub(userHubId) ||
+                            delivery.getRoutes().stream().anyMatch(r -> r.isRelatedToHub(userHubId));
+
+            if (!permitted) throw new BusinessException(ErrorCode.FORBIDDEN_DELIVERY_READ);
             return;
         }
 
+        // 배송 담당자: 업체 배송담당자, 어떤 경로의 허브 배송담당자도 허용
         if (currentUserRole.isDeliveryManager()) {
-            if (!delivery.isAssignedTo(currentUserId)) {
+            boolean isCompanyDeliveryManager = delivery.isAssignedTo(currentUserId);
+            boolean isAnyHubRouteManager = delivery.getRoutes().stream()
+                    .anyMatch(r -> r.getHubDeliveryManager() != null
+                            && currentUserId.equals(r.getHubDeliveryManager().getDeliveryManagerId()));
+
+            if (!(isCompanyDeliveryManager || isAnyHubRouteManager)) {
                 throw new BusinessException(ErrorCode.FORBIDDEN_DELIVERY_READ);
             }
             return;
@@ -185,7 +196,7 @@ public class DeliveryService {
     public void deleteDelivery(UUID deliveryId, Long currentUserId, UserRole currentUserRole) {
         log.info("[Delivery] 배송 삭제. deliveryId: {}", deliveryId);
 
-        Delivery delivery = findDeliveryById(deliveryId);
+        Delivery delivery = findDeliveryByIdWithRoutes(deliveryId);
         validateDeletePermission(delivery, currentUserId, currentUserRole);
 
         delivery.delete(currentUserId);

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/application/service/DeliveryService.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/application/service/DeliveryService.java
@@ -176,4 +176,36 @@ public class DeliveryService {
 
         throw new BusinessException(ErrorCode.FORBIDDEN_DELIVERY_MODIFY);
     }
+
+    @Transactional
+    public void deleteDelivery(UUID deliveryId, Long currentUserId, UserRole currentUserRole) {
+        log.info("[Delivery] 배송 삭제. deliveryId: {}", deliveryId);
+
+        Delivery delivery = findDeliveryById(deliveryId);
+        validateDeletePermission(delivery, currentUserId, currentUserRole);
+
+        delivery.delete(currentUserId);
+
+        log.info("[Delivery] 배송 삭제 완료. deliveryId: {}", deliveryId);
+    }
+
+    private void validateDeletePermission(Delivery delivery, Long currentUserId, UserRole currentUserRole) {
+        if (currentUserRole == null) {
+            throw new BusinessException(ErrorCode.FORBIDDEN_DELIVERY_DELETE);
+        }
+
+        // 마스터 관리자: 허용
+        if (currentUserRole.isMaster()) return;
+
+        // 허브 관리자: 본인 허브와 관련된 배송만 삭제 가능
+        if (currentUserRole.isHubManager()) {
+            UUID userHubId = hubService.getUserHubId(currentUserId);
+            if (!delivery.isRelatedToHub(userHubId)) {
+                throw new BusinessException(ErrorCode.FORBIDDEN_DELIVERY_DELETE);
+            }
+            return;
+        }
+        // 업체 담당자, 배송 담당자: 삭제 불가
+        throw new BusinessException(ErrorCode.FORBIDDEN_DELIVERY_DELETE);
+    }
 }

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/application/service/DeliveryService.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/application/service/DeliveryService.java
@@ -18,7 +18,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 /**
  * 배송 서비스
@@ -68,7 +67,7 @@ public class DeliveryService {
                         seg.durationMinutes(),
                         hubManager
                 ))
-                .collect(Collectors.toList());
+                .toList();
 
         // 업체 배송 담당자 배정
         DeliveryManager companyManager = domainService.assignCompanyDeliveryManager(request.arrivalHubId());
@@ -90,7 +89,7 @@ public class DeliveryService {
                 savedDelivery.getDeliveryId(), savedDelivery.getRoutes().size());
 
         // 응답 반환
-        return CreateDeliveryResponse.from(savedDelivery);
+        return CreateDeliveryResponse.of(savedDelivery, companyManager, routes);
     }
 
     public DeliveryResponse getDelivery(UUID deliveryId, Long currentUserId, UserRole currentUserRole) {

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/application/service/DeliveryService.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/application/service/DeliveryService.java
@@ -15,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * 배송 서비스
@@ -39,52 +40,55 @@ public class DeliveryService {
     public CreateDeliveryResponse createDelivery(CreateDeliveryRequest request, Long currentUserId) {
         log.info("[Delivery] 배송 생성 시작. orderId: {}", request.orderId());
 
+        // 기본 검증
         if (deliveryRepository.existsByOrderId(request.orderId())) {
             throw new BusinessException(ErrorCode.DUPLICATE_DELIVERY);
         }
-
         orderService.validateOrderExists(request.orderId());
         hubService.validateHubExists(request.departureHubId());
         hubService.validateHubExists(request.arrivalHubId());
 
-        DeliveryRoutePlan deliveryRoutePlan = hubService.getDeliveryRoutePlan(
+        // 경로 계획 가져오기
+        DeliveryRoutePlan plan = hubService.getDeliveryRoutePlan(
                 request.departureHubId(), request.arrivalHubId()
         );
 
+        // 허브 배송 담당자 배정
+        DeliveryManager hubManager = domainService.assignHubDeliveryManager();
+
+        // 배송 경로 생성
+        List<DeliveryRoute> routes = plan.routes().stream()
+                .map(seg -> DeliveryRoute.create(
+                        seg.sequence(),
+                        seg.departureHubId(),
+                        seg.arrivalHubId(),
+                        seg.distanceKm(),
+                        seg.durationMinutes(),
+                        hubManager
+                ))
+                .collect(Collectors.toList());
+
+        // 업체 배송 담당자 배정
         DeliveryManager companyManager = domainService.assignCompanyDeliveryManager(request.arrivalHubId());
 
+        // 배송 생성(경로 리스트 포함) → 부모만 저장하면 자식도 PERSIST
         Delivery delivery = Delivery.create(
                 request.orderId(),
                 request.departureHubId(),
                 request.arrivalHubId(),
                 DeliveryAddress.of(request.deliveryAddress()),
                 Recipient.of(request.recipientName(), request.recipientSlackId()),
-                companyManager
+                companyManager,
+                routes
         );
 
-        Delivery savedDelivery = deliveryRepository.save(delivery);
+        Delivery savedDelivery = deliveryRepository.save(delivery); // cascade로 routes INSERT + FK 주입
 
-        for (DeliveryRouteSegment routeSegment : deliveryRoutePlan.routes()) {
-            DeliveryManager hubManager = domainService.assignHubDeliveryManager();
+        log.info("[Delivery] 배송 생성 완료. deliveryId: {}, routes: {}",
+                savedDelivery.getDeliveryId(), savedDelivery.getRoutes().size());
 
-            DeliveryRoute route = DeliveryRoute.create(
-                    savedDelivery,
-                    routeSegment.sequence(),
-                    routeSegment.departureHubId(),
-                    routeSegment.arrivalHubId(),
-                    routeSegment.distanceKm(),
-                    routeSegment.durationMinutes(),
-                    hubManager
-            );
-
-            deliveryRouteRepository.save(route);
-        }
-
-        List<DeliveryRoute> routes = deliveryRouteRepository.findByDeliveryIdOrderBySequence(savedDelivery.getDeliveryId());
-
-        log.info("[Delivery] 배송 생성 완료. deliveryId: {}, routes: {}", savedDelivery.getDeliveryId(), routes.size());
-
-        return CreateDeliveryResponse.from(savedDelivery, routes);
+        // 응답 반환
+        return CreateDeliveryResponse.from(savedDelivery);
     }
 
     public DeliveryResponse getDelivery(UUID deliveryId, Long currentUserId, UserRole currentUserRole) {

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/application/service/HubService.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/application/service/HubService.java
@@ -1,5 +1,7 @@
 package com.luckylogistics.delivery.application.service;
 
+import com.luckylogistics.delivery.application.dto.DeliveryRoutePlan;
+
 import java.util.UUID;
 
 public interface HubService {
@@ -13,5 +15,11 @@ public interface HubService {
      * 요청 사용자의 Hub ID 조회
      * HUB_MANAGER의 담당 허브 확인 (권한)
      */
-    public UUID getUserHubId(Long userId);
+    UUID getUserHubId(Long userId);
+
+    /**
+     * 배송 경로 조회
+     * 허브 간 거리, 예상 소요 시간 등을 포함한 경로 정보를 반환
+     */
+    DeliveryRoutePlan getDeliveryRoutePlan(UUID departureHubId, UUID arrivalHubId);
 }

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/application/service/OrderService.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/application/service/OrderService.java
@@ -1,0 +1,7 @@
+package com.luckylogistics.delivery.application.service;
+
+import java.util.UUID;
+
+public interface OrderService {
+    void validateOrderExists(UUID orderId);
+}

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/common/exception/ErrorCode.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/common/exception/ErrorCode.java
@@ -22,9 +22,25 @@ public enum ErrorCode {
     INVALID_USER_ROLE(HttpStatus.CONFLICT, "DM-003", "배송 담당자 권한이 없습니다"),
     DELIVERY_MANAGER_SELF_ONLY(HttpStatus.FORBIDDEN, "DM-004","배송 담당자는 본인 정보만 조회할 수 있습니다"),
 
+    // Delivery
+    DELIVERY_NOT_FOUND(HttpStatus.NOT_FOUND, "DD-001", "배송을 찾을 수 없습니다"),
+    DELIVERY_DELETED(HttpStatus.BAD_REQUEST, "DD-002", "삭제된 배송입니다"),
+    DUPLICATE_DELIVERY(HttpStatus.CONFLICT, "DD-003", "이미 배송이 생성된 주문입니다"),
+
+    // DeliveryRoute
+    DELIVERY_ROUTE_NOT_FOUND(HttpStatus.NOT_FOUND, "DR-001", "배송 경로를 찾을 수 없습니다"),
+    DELIVERY_ROUTE_DELETED(HttpStatus.BAD_REQUEST, "DR-002", "삭제된 배송 경로입니다"),
+
+
     // Hub
     HUB_MANAGER_FORBIDDEN(HttpStatus.FORBIDDEN, "H-001","허브 관리자는 다른 허브의 데이터를 조회할 수 없습니다"),
     USER_HUB_NOT_FOUND(HttpStatus.NOT_FOUND, "H-002", "허브 관리자의 담당 허브 정보를 찾을 수 없습니다"),
+    HUB_NOT_FOUND(HttpStatus.NOT_FOUND, "H-003", "허브를 찾을 수 없습니다"),
+    HUB_SERVICE_ERROR(HttpStatus.SERVICE_UNAVAILABLE, "H-004", "허브 서비스 오류가 발생했습니다"),
+
+    // Order
+    ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "O-001", "주문을 찾을 수 없습니다"),
+    ORDER_SERVICE_ERROR(HttpStatus.SERVICE_UNAVAILABLE, "O-002", "주문 서비스 오류가 발생했습니다"),
 
     // User
     USER_ROLE_UNAUTHORIZED(HttpStatus.FORBIDDEN, "U-001", "해당 권한으로는 접근할 수 없습니다")

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/common/exception/ErrorCode.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/common/exception/ErrorCode.java
@@ -26,6 +26,7 @@ public enum ErrorCode {
     DELIVERY_NOT_FOUND(HttpStatus.NOT_FOUND, "DD-001", "배송을 찾을 수 없습니다"),
     DELIVERY_DELETED(HttpStatus.BAD_REQUEST, "DD-002", "삭제된 배송입니다"),
     DUPLICATE_DELIVERY(HttpStatus.CONFLICT, "DD-003", "이미 배송이 생성된 주문입니다"),
+    FORBIDDEN_DELIVERY_READ(HttpStatus.FORBIDDEN, "DD-004", "해당 배송을 조회할 권한이 없습니다"),
 
     // DeliveryRoute
     DELIVERY_ROUTE_NOT_FOUND(HttpStatus.NOT_FOUND, "DR-001", "배송 경로를 찾을 수 없습니다"),

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/common/exception/ErrorCode.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/common/exception/ErrorCode.java
@@ -27,11 +27,17 @@ public enum ErrorCode {
     DELIVERY_DELETED(HttpStatus.BAD_REQUEST, "DD-002", "삭제된 배송입니다"),
     DUPLICATE_DELIVERY(HttpStatus.CONFLICT, "DD-003", "이미 배송이 생성된 주문입니다"),
     FORBIDDEN_DELIVERY_READ(HttpStatus.FORBIDDEN, "DD-004", "해당 배송을 조회할 권한이 없습니다"),
+    FORBIDDEN_DELIVERY_MODIFY(HttpStatus.FORBIDDEN, "DD-005", "해당 배송을 수정할 권한이 없습니다"),
+    FORBIDDEN_DELIVERY_DELETE(HttpStatus.FORBIDDEN, "DD-006", "해당 배송을 삭제할 권한이 없습니다"),
+    FORBIDDEN_NOT_HUB_DELIVERY(HttpStatus.FORBIDDEN, "DD-007", "담당 허브의 배송이 아닙니다"),
+    FORBIDDEN_NOT_COMPANY_DELIVERY(HttpStatus.FORBIDDEN, "DD-008", "담당 배송이 아닙니다"),
+    FORBIDDEN_NOT_ASSIGNED_ROUTE(HttpStatus.FORBIDDEN, "DD-009", "배정된 경로가 아닙니다"),
 
     // DeliveryRoute
     DELIVERY_ROUTE_NOT_FOUND(HttpStatus.NOT_FOUND, "DR-001", "배송 경로를 찾을 수 없습니다"),
     DELIVERY_ROUTE_DELETED(HttpStatus.BAD_REQUEST, "DR-002", "삭제된 배송 경로입니다"),
-
+    FORBIDDEN_ROUTE_READ(HttpStatus.FORBIDDEN, "DR-003", "해당 배송 경로를 조회할 권한이 없습니다"),
+    FORBIDDEN_ROUTE_MODIFY(HttpStatus.FORBIDDEN, "DR-004", "해당 배송 경로를 수정할 권한이 없습니다"),
 
     // Hub
     HUB_MANAGER_FORBIDDEN(HttpStatus.FORBIDDEN, "H-001","허브 관리자는 다른 허브의 데이터를 조회할 수 없습니다"),

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/common/exception/ErrorCode.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/common/exception/ErrorCode.java
@@ -32,6 +32,7 @@ public enum ErrorCode {
     FORBIDDEN_NOT_HUB_DELIVERY(HttpStatus.FORBIDDEN, "DD-007", "담당 허브의 배송이 아닙니다"),
     FORBIDDEN_NOT_COMPANY_DELIVERY(HttpStatus.FORBIDDEN, "DD-008", "담당 배송이 아닙니다"),
     FORBIDDEN_NOT_ASSIGNED_ROUTE(HttpStatus.FORBIDDEN, "DD-009", "배정된 경로가 아닙니다"),
+    FORBIDDEN_DELIVERY_SEARCH(HttpStatus.FORBIDDEN, "DD-010", "해당 배송 목록을 조회할 권한이 없습니다."),
 
     // DeliveryRoute
     DELIVERY_ROUTE_NOT_FOUND(HttpStatus.NOT_FOUND, "DR-001", "배송 경로를 찾을 수 없습니다"),

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/common/response/ApiResponse.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/common/response/ApiResponse.java
@@ -15,16 +15,18 @@ public record ApiResponse<T>(
         String code
 ) {
 
-    /**
-     * 성공 응답 생성 (데이터 + 메시지)
-     */
+    /** 성공 응답 생성 (데이터 + 메시지) */
+    // 성공 - 데이터 있음
     public static <T> ApiResponse<T> success(T data, String message) {
         return new ApiResponse<>(true, message, data, null);
     }
 
-    /**
-     * 실패 응답 생성 (에러 코드 + 메시지)
-     */
+    // 성공 - 데이터 없음
+    public static <T> ApiResponse<T> success(String message) {
+        return new ApiResponse<>(true, message, null, null);
+    }
+
+    /** 실패 응답 생성 (에러 코드 + 메시지) */
     public static <T> ApiResponse<T> error(ErrorCode errorCode) {
         return new ApiResponse<>(false, errorCode.getMessage(), null, errorCode.getCode());
     }

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/domain/model/Delivery.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/domain/model/Delivery.java
@@ -1,0 +1,99 @@
+package com.luckylogistics.delivery.domain.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.UUID;
+
+@Getter
+@Entity
+@Table(name = "p_delivery")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+public class Delivery extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "delivery_id", nullable = false)
+    private UUID deliveryId;
+
+    @Column(name = "order_id", nullable = false, unique = true)
+    private UUID orderId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private DeliveryStatus status;
+
+    @Column(name = "departure_hub_id", nullable = false)
+    private UUID departureHubId;
+
+    @Column(name = "arrival_hub_id", nullable = false)
+    private UUID arrivalHubId;
+
+    @Embedded
+    private DeliveryAddress deliveryAddress;
+
+    @Embedded
+    private Recipient recipient;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "company_delivery_manager_id", nullable = false)
+    private DeliveryManager companyDeliveryManager;
+
+    /**
+     * 배송 생성
+     * Order Service에서 주문 생성 시 호출
+     */
+    public static Delivery create(
+            UUID orderId,
+            UUID departureHubId,
+            UUID arrivalHubId,
+            DeliveryAddress deliveryAddress,
+            Recipient recipient,
+            DeliveryManager companyDeliveryManager
+    ) {
+        validateOrderId(orderId);
+        validateHubIds(departureHubId, arrivalHubId);
+        validateCompanyDeliveryManager(companyDeliveryManager);
+
+        return Delivery.builder()
+                .orderId(orderId)
+                .status(DeliveryStatus.HUB_WAITING)
+                .departureHubId(departureHubId)
+                .arrivalHubId(arrivalHubId)
+                .deliveryAddress(deliveryAddress)
+                .recipient(recipient)
+                .companyDeliveryManager(companyDeliveryManager)
+                .build();
+    }
+
+    private static void validateOrderId(UUID orderId) {
+        if (orderId == null) {
+            throw new IllegalArgumentException("주문 ID는 필수입니다");
+        }
+    }
+
+    private static void validateHubIds(UUID departureHubId, UUID arrivalHubId) {
+        if (departureHubId == null || arrivalHubId == null) {
+            throw new IllegalArgumentException("출발/도착 허브 ID는 필수입니다");
+        }
+        if (departureHubId.equals(arrivalHubId)) {
+            throw new IllegalArgumentException("출발 허브와 도착 허브는 달라야 합니다");
+        }
+    }
+
+    private static void validateCompanyDeliveryManager(DeliveryManager manager) {
+        if (manager == null) {
+            throw new IllegalArgumentException("업체 배송 담당자는 필수입니다");
+        }
+    }
+
+    /**
+     * 배송 상태 변경
+     */
+    public void changeStatus(DeliveryStatus newStatus) {
+        this.status.validateTransition(newStatus);
+        this.status = newStatus;
+    }
+}

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/domain/model/Delivery.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/domain/model/Delivery.java
@@ -3,7 +3,8 @@ package com.luckylogistics.delivery.domain.model;
 import jakarta.persistence.*;
 import lombok.*;
 
-import java.util.UUID;
+import java.util.*;
+import java.util.stream.Collectors;
 
 @Getter
 @Entity
@@ -37,9 +38,21 @@ public class Delivery extends BaseEntity {
     @Embedded
     private Recipient recipient;
 
+    /**
+     * 업체 배송 담당자 (도착 허브 → 최종 목적지)
+     */
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "company_delivery_manager_id", nullable = false)
     private DeliveryManager companyDeliveryManager;
+
+    /**
+     * 배송 경로 1:N (단방향, 부모가 FK 관리)
+     * - 생성/갱신 위해 PERSIST, MERGE 사용
+     */
+    @OneToMany(fetch = FetchType.LAZY, cascade = { CascadeType.PERSIST, CascadeType.MERGE })
+    @JoinColumn(name = "delivery_id", nullable = false, updatable = false)
+    @OrderBy("sequence ASC")
+    private List<DeliveryRoute> routes = new ArrayList<>();
 
     /**
      * 배송 생성
@@ -51,11 +64,19 @@ public class Delivery extends BaseEntity {
             UUID arrivalHubId,
             DeliveryAddress deliveryAddress,
             Recipient recipient,
-            DeliveryManager companyDeliveryManager
+            DeliveryManager companyDeliveryManager,
+            List<DeliveryRoute> routes
     ) {
         validateOrderId(orderId);
         validateHubIds(departureHubId, arrivalHubId);
         validateCompanyDeliveryManager(companyDeliveryManager);
+        validateRoutes(routes);
+
+        // null 제거 + sequence 기준 정렬
+        List<DeliveryRoute> normalizedRoutes = routes.stream()
+                .filter(Objects::nonNull)
+                .sorted(Comparator.comparing(DeliveryRoute::getSequence)) // 연결성 검증은 제외
+                .collect(Collectors.toList());
 
         return Delivery.builder()
                 .orderId(orderId)
@@ -65,6 +86,7 @@ public class Delivery extends BaseEntity {
                 .deliveryAddress(deliveryAddress)
                 .recipient(recipient)
                 .companyDeliveryManager(companyDeliveryManager)
+                .routes(normalizedRoutes)
                 .build();
     }
 
@@ -86,6 +108,12 @@ public class Delivery extends BaseEntity {
     private static void validateCompanyDeliveryManager(DeliveryManager manager) {
         if (manager == null) {
             throw new IllegalArgumentException("업체 배송 담당자는 필수입니다");
+        }
+    }
+
+    private static void validateRoutes(List<DeliveryRoute> routes) {
+        if (routes == null || routes.isEmpty()) {
+            throw new IllegalArgumentException("배송 경로는 최소 1개 이상이어야 합니다.");
         }
     }
 

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/domain/model/Delivery.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/domain/model/Delivery.java
@@ -96,4 +96,17 @@ public class Delivery extends BaseEntity {
         this.status.validateTransition(newStatus);
         this.status = newStatus;
     }
+
+    // 속한 허브인지
+    public boolean isRelatedToHub(UUID hubId) {
+        if (hubId == null) {
+            return false;
+        }
+        return departureHubId.equals(hubId) || arrivalHubId.equals(hubId);
+    }
+
+    // 업체 배송 담당자 인지
+    public boolean isAssignedTo(Long userId) {
+        return this.companyDeliveryManager.getDeliveryManagerId().equals(userId);
+    }
 }

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/domain/model/Delivery.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/domain/model/Delivery.java
@@ -184,4 +184,18 @@ public class Delivery extends BaseEntity {
         }
         return this.arrivalHubId.equals(hubId);
     }
+
+    public void deleteCascade(Long deletedBy) {
+        if (isDeleted()) return; // 중복 방지
+
+        // 경로 논리삭제
+        if (routes != null && !routes.isEmpty()) {
+            routes.stream()
+                    .filter(r -> !r.isDeleted())
+                    .forEach(r -> r.delete(deletedBy));
+        }
+
+        // 배송 논리삭제
+        this.delete(deletedBy);
+    }
 }

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/domain/model/Delivery.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/domain/model/Delivery.java
@@ -4,7 +4,6 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.util.*;
-import java.util.stream.Collectors;
 
 @Getter
 @Entity
@@ -76,7 +75,7 @@ public class Delivery extends BaseEntity {
         List<DeliveryRoute> normalizedRoutes = routes.stream()
                 .filter(Objects::nonNull)
                 .sorted(Comparator.comparing(DeliveryRoute::getSequence)) // 연결성 검증은 제외
-                .collect(Collectors.toList());
+                .toList();
 
         return Delivery.builder()
                 .orderId(orderId)

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/domain/model/Delivery.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/domain/model/Delivery.java
@@ -91,10 +91,49 @@ public class Delivery extends BaseEntity {
 
     /**
      * 배송 상태 변경
+     * @param byApi true면 API 요청으로 인한 변경, false면 시스템 내부(허브 경로 전파 등)에 의한 변경
      */
-    public void changeStatus(DeliveryStatus newStatus) {
+    public void changeStatus(DeliveryStatus newStatus, boolean byApi) {
+        // 상태 값 검증
+        validateStatus(newStatus);
+
+        // API 호출일 때 허브 구간 상태로 변경 금지
+        if (byApi && newStatus.isHubPhase()) {
+            throw new IllegalStateException("허브 구간 상태로는 API로 직접 변경할 수 없습니다. 경로 진행으로만 변경됩니다.");
+        }
+
+        // 동일 상태면 무시
+        if (this.status == newStatus) return;
+
+        // 상태 전환 규칙 검증
         this.status.validateTransition(newStatus);
+        // 업체 구간 전환 제약 검증
+        validateCompanyPhaseTransition(newStatus);
+
+        // 상태 변경
         this.status = newStatus;
+    }
+
+    private static void validateStatus(DeliveryStatus status) {
+        if (status == null) {
+            throw new IllegalArgumentException("변경할 배송 상태는 필수입니다.");
+        }
+    }
+
+    /**
+     * HUB_ARRIVED 이후에만 업체 배송 가능,
+     * COMPANY_MOVING 이후에만 배송 완료 가능
+     */
+    private void validateCompanyPhaseTransition(DeliveryStatus nextStatus) {
+        // HUB_ARRIVED 이후에만 업체 배송 시작 가능
+        if (nextStatus.isCompanyMoving() && !this.status.isHubArrived()) {
+            throw new IllegalStateException("목적지 허브 도착(HUB_ARRIVED) 이후에만 업체 배송을 시작할 수 있습니다.");
+        }
+
+        // COMPANY_MOVING 이후에만 배송 완료 가능
+        if (nextStatus.isCompleted() && !this.status.isCompanyMoving()) {
+            throw new IllegalStateException("업체 배송 중(COMPANY_MOVING) 상태에서만 배송 완료가 가능합니다.");
+        }
     }
 
     // 속한 허브인지
@@ -108,5 +147,13 @@ public class Delivery extends BaseEntity {
     // 업체 배송 담당자 인지
     public boolean isAssignedTo(Long userId) {
         return this.companyDeliveryManager.getDeliveryManagerId().equals(userId);
+    }
+
+     // 특정 허브가 도착 허브인지
+    public boolean isArrivalHub(UUID hubId) {
+        if (hubId == null || this.arrivalHubId == null) {
+            return false;
+        }
+        return this.arrivalHubId.equals(hubId);
     }
 }

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/domain/model/DeliveryAddress.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/domain/model/DeliveryAddress.java
@@ -1,0 +1,42 @@
+package com.luckylogistics.delivery.domain.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 배송지 주소 값 객체
+ */
+@Embeddable
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DeliveryAddress {
+
+    private static final int MAX_LENGTH = 500;
+
+    @Column(name = "delivery_address", nullable = false, length = 500)
+    private String deliveryAddress;
+
+    private DeliveryAddress(String deliveryAddress) {
+        validate(deliveryAddress);
+        this.deliveryAddress = deliveryAddress;
+    }
+
+    public static DeliveryAddress of(String deliveryAddress) {
+        return new DeliveryAddress(deliveryAddress);
+    }
+
+    private void validate(String deliveryAddress) {
+        if (deliveryAddress == null || deliveryAddress.isBlank()) {
+            throw new IllegalArgumentException("배송지 주소는 필수입니다");
+        }
+        if (deliveryAddress.length() > MAX_LENGTH) {
+            throw new IllegalArgumentException(
+                    String.format("배송지 주소는 %d자 이하여야 합니다", MAX_LENGTH));
+        }
+    }
+}

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/domain/model/DeliveryRoute.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/domain/model/DeliveryRoute.java
@@ -1,0 +1,147 @@
+package com.luckylogistics.delivery.domain.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+@Getter
+@Entity
+@Table(name = "p_delivery_route")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+public class DeliveryRoute extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "delivery_route_id", nullable = false)
+    private UUID deliveryRouteId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "delivery_id", nullable = false)
+    private Delivery delivery;
+
+    @Column(name = "sequence", nullable = false)
+    private Integer sequence;
+
+    @Column(name = "departure_hub_id", nullable = false)
+    private UUID departureHubId;
+
+    @Column(name = "arrival_hub_id", nullable = false)
+    private UUID arrivalHubId;
+
+    @Column(name = "estimated_distance", nullable = false, precision = 10, scale = 2)
+    private BigDecimal estimatedDistance;
+
+    @Column(name = "estimated_duration", nullable = false)
+    private Integer estimatedDuration;
+
+    @Column(name = "actual_distance", precision = 10, scale = 2)
+    private BigDecimal actualDistance;
+
+    @Column(name = "actual_duration")
+    private Integer actualDuration;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private DeliveryRouteStatus status;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "hub_delivery_manager_id", nullable = false)
+    private DeliveryManager hubDeliveryManager;
+
+    /**
+     * 배송 경로 생성
+     */
+    public static DeliveryRoute create(
+            Delivery delivery,
+            Integer sequence,
+            UUID departureHubId,
+            UUID arrivalHubId,
+            BigDecimal estimatedDistance,
+            Integer estimatedDuration,
+            DeliveryManager deliveryManager
+    ) {
+        validateDelivery(delivery);
+        validateSequence(sequence);
+        validateHubIds(departureHubId, arrivalHubId);
+        validateEstimatedValues(estimatedDistance, estimatedDuration);
+        validateDeliveryManager(deliveryManager);
+
+        return DeliveryRoute.builder()
+                .delivery(delivery)
+                .sequence(sequence)
+                .departureHubId(departureHubId)
+                .arrivalHubId(arrivalHubId)
+                .estimatedDistance(estimatedDistance)
+                .estimatedDuration(estimatedDuration)
+                .status(DeliveryRouteStatus.HUB_WAITING)
+                .hubDeliveryManager(deliveryManager)
+                .build();
+    }
+
+    private static void validateDelivery(Delivery delivery) {
+        if (delivery == null) {
+            throw new IllegalArgumentException("배송 정보는 필수입니다");
+        }
+    }
+
+    private static void validateSequence(Integer sequence) {
+        if (sequence == null || sequence < 1) {
+            throw new IllegalArgumentException("경로 순서는 1 이상이어야 합니다");
+        }
+    }
+
+    private static void validateHubIds(UUID departureHubId, UUID arrivalHubId) {
+        if (departureHubId == null || arrivalHubId == null) {
+            throw new IllegalArgumentException("출발/도착 허브 ID는 필수입니다");
+        }
+        if (departureHubId.equals(arrivalHubId)) {
+            throw new IllegalArgumentException("출발 허브와 도착 허브는 달라야 합니다");
+        }
+    }
+
+    private static void validateEstimatedValues(BigDecimal distance, Integer duration) {
+        if (distance == null || distance.compareTo(BigDecimal.ZERO) <= 0) {
+            throw new IllegalArgumentException("예상 거리는 0보다 커야 합니다");
+        }
+        if (duration == null || duration <= 0) {
+            throw new IllegalArgumentException("예상 소요 시간은 0보다 커야 합니다");
+        }
+    }
+
+    private static void validateDeliveryManager(DeliveryManager manager) {
+        if (manager == null) {
+            throw new IllegalArgumentException("배송 담당자는 필수입니다");
+        }
+        if (!manager.getType().isHubDelivery()) {
+            throw new IllegalArgumentException("허브 간 경로는 허브 배송 담당자만 담당할 수 있습니다");
+        }
+    }
+
+    private void validateActualValues(BigDecimal distance, Integer duration) {
+        if (distance == null || distance.compareTo(BigDecimal.ZERO) <= 0) {
+            throw new IllegalArgumentException("실제 거리는 0보다 커야 합니다");
+        }
+        if (duration == null || duration <= 0) {
+            throw new IllegalArgumentException("실제 소요 시간은 0보다 커야 합니다");
+        }
+    }
+
+    /**
+     * 경로 상태 변경
+     */
+    public void changeStatus(DeliveryRouteStatus newStatus, BigDecimal actualDistance, Integer actualDuration) {
+        this.status.validateTransition(newStatus);
+
+        if (newStatus.isArrived()) {
+            validateActualValues(actualDistance, actualDuration);
+            this.actualDistance = actualDistance;
+            this.actualDuration = actualDuration;
+        }
+
+        this.status = newStatus;
+    }
+}

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/domain/model/DeliveryRoute.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/domain/model/DeliveryRoute.java
@@ -144,4 +144,11 @@ public class DeliveryRoute extends BaseEntity {
 
         this.status = newStatus;
     }
+
+    public boolean isRelatedToHub(UUID hubId) {
+        if (hubId == null) {
+            return false;
+        }
+        return departureHubId.equals(hubId) || arrivalHubId.equals(hubId);
+    }
 }

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/domain/model/DeliveryRoute.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/domain/model/DeliveryRoute.java
@@ -19,9 +19,12 @@ public class DeliveryRoute extends BaseEntity {
     @Column(name = "delivery_route_id", nullable = false)
     private UUID deliveryRouteId;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "delivery_id", nullable = false)
-    private Delivery delivery;
+    /**
+     * 부모가 @JoinColumn(name="delivery_id")로 FK를 관리
+     * 참조 없이 FK 컬럼만 읽기용
+     */
+    @Column(name = "delivery_id", nullable = false, insertable = false, updatable = false)
+    private UUID deliveryId;
 
     @Column(name = "sequence", nullable = false)
     private Integer sequence;
@@ -56,7 +59,6 @@ public class DeliveryRoute extends BaseEntity {
      * 배송 경로 생성
      */
     public static DeliveryRoute create(
-            Delivery delivery,
             Integer sequence,
             UUID departureHubId,
             UUID arrivalHubId,
@@ -64,14 +66,12 @@ public class DeliveryRoute extends BaseEntity {
             Integer estimatedDuration,
             DeliveryManager deliveryManager
     ) {
-        validateDelivery(delivery);
         validateSequence(sequence);
         validateHubIds(departureHubId, arrivalHubId);
         validateEstimatedValues(estimatedDistance, estimatedDuration);
         validateDeliveryManager(deliveryManager);
 
         return DeliveryRoute.builder()
-                .delivery(delivery)
                 .sequence(sequence)
                 .departureHubId(departureHubId)
                 .arrivalHubId(arrivalHubId)
@@ -80,12 +80,6 @@ public class DeliveryRoute extends BaseEntity {
                 .status(DeliveryRouteStatus.HUB_WAITING)
                 .hubDeliveryManager(deliveryManager)
                 .build();
-    }
-
-    private static void validateDelivery(Delivery delivery) {
-        if (delivery == null) {
-            throw new IllegalArgumentException("배송 정보는 필수입니다");
-        }
     }
 
     private static void validateSequence(Integer sequence) {

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/domain/model/DeliveryRouteStatus.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/domain/model/DeliveryRouteStatus.java
@@ -1,0 +1,58 @@
+package com.luckylogistics.delivery.domain.model;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 배송 경로 상태
+ */
+@Getter
+@RequiredArgsConstructor
+public enum DeliveryRouteStatus {
+
+    HUB_WAITING("허브 대기") {
+        @Override
+        public boolean canTransitionTo(DeliveryRouteStatus newStatus) {
+            return newStatus == HUB_MOVING;
+        }
+    },
+
+    HUB_MOVING("허브 이동 중") {
+        @Override
+        public boolean canTransitionTo(DeliveryRouteStatus newStatus) {
+            return newStatus == HUB_ARRIVED;
+        }
+    },
+
+    HUB_ARRIVED("허브 도착") {
+        @Override
+        public boolean canTransitionTo(DeliveryRouteStatus newStatus) {
+            return false; // 도착 후 상태 변경 불가
+        }
+    };
+
+    private final String description;
+
+    /**
+     * 상태 전환 가능 여부 검증
+     */
+    public abstract boolean canTransitionTo(DeliveryRouteStatus newStatus);
+
+    /**
+     * 상태 전환 검증 및 예외 발생
+     */
+    public void validateTransition(DeliveryRouteStatus newStatus) {
+        if (!canTransitionTo(newStatus)) {
+            throw new IllegalStateException(
+                    String.format("%s 상태에서 %s 상태로 변경할 수 없습니다",
+                            this.description, newStatus.description));
+        }
+    }
+
+    /**
+     * 경로 도착 여부
+     */
+    public boolean isArrived() {
+        return this == DeliveryRouteStatus.HUB_ARRIVED;
+    }
+}

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/domain/model/DeliveryStatus.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/domain/model/DeliveryStatus.java
@@ -1,0 +1,72 @@
+package com.luckylogistics.delivery.domain.model;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 배송 상태
+ */
+@Getter
+@RequiredArgsConstructor
+public enum DeliveryStatus {
+
+    HUB_WAITING("허브 대기") {
+        @Override
+        public boolean canTransitionTo(DeliveryStatus newStatus) {
+            return newStatus == HUB_MOVING;
+        }
+    },
+
+    HUB_MOVING("허브 간 이동 중") {
+        @Override
+        public boolean canTransitionTo(DeliveryStatus newStatus) {
+            return newStatus == HUB_ARRIVED;
+        }
+    },
+
+    HUB_ARRIVED("목적지 허브 도착") {
+        @Override
+        public boolean canTransitionTo(DeliveryStatus newStatus) {
+            return newStatus == COMPANY_MOVING;
+        }
+    },
+
+    COMPANY_MOVING("업체 배송 중") {
+        @Override
+        public boolean canTransitionTo(DeliveryStatus newStatus) {
+            return newStatus == COMPLETED;
+        }
+    },
+
+    COMPLETED("배송 완료") {
+        @Override
+        public boolean canTransitionTo(DeliveryStatus newStatus) {
+            return false; // 완료 후 상태 변경 불가
+        }
+    };
+
+    private final String description;
+
+    /**
+     * 상태 전환 가능 여부 검증
+     */
+    public abstract boolean canTransitionTo(DeliveryStatus newStatus);
+
+    /**
+     * 상태 전환 검증 및 예외 발생
+     */
+    public void validateTransition(DeliveryStatus newStatus) {
+        if (!canTransitionTo(newStatus)) {
+            throw new IllegalStateException(
+                    String.format("%s 상태에서 %s 상태로 변경할 수 없습니다",
+                            this.description, newStatus.description));
+        }
+    }
+
+    /**
+     * 배송이 완료되었는지 확인
+     */
+    public boolean isCompleted() {
+        return this == DeliveryStatus.COMPLETED;
+    }
+}

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/domain/model/DeliveryStatus.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/domain/model/DeliveryStatus.java
@@ -63,10 +63,38 @@ public enum DeliveryStatus {
         }
     }
 
-    /**
-     * 배송이 완료되었는지 확인
-     */
+    /** 업체 배송 중 상태 확인 */
+    public boolean isCompanyMoving() {
+        return this == COMPANY_MOVING;
+    }
+
+    /** 배송 완료 상태 확인 */
     public boolean isCompleted() {
-        return this == DeliveryStatus.COMPLETED;
+        return this == COMPLETED;
+    }
+
+    /** 목적지 허브 도착 상태 확인 */
+    public boolean isHubArrived() {
+        return this == HUB_ARRIVED;
+    }
+
+    /** 허브 대기 상태 확인 */
+    public boolean isHubWaiting() {
+        return this == HUB_WAITING;
+    }
+
+    /** 허브 이동 중 상태 확인 */
+    public boolean isHubMoving() {
+        return this == HUB_MOVING;
+    }
+
+    /** 허브 관련 단계 확인 (대기/이동중/도착) */
+    public boolean isHubPhase() {
+        return this == HUB_WAITING || this == HUB_MOVING || this == HUB_ARRIVED;
+    }
+
+    /** 업체 관련 단계 확인 (배송중/완료) */
+    public boolean isCompanyPhase() {
+        return this == COMPANY_MOVING || this == COMPLETED;
     }
 }

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/domain/model/Recipient.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/domain/model/Recipient.java
@@ -1,0 +1,61 @@
+package com.luckylogistics.delivery.domain.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.regex.Pattern;
+
+/**
+ * 수령인 정보 값 객체
+ */
+@Embeddable
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Recipient {
+
+    // 이메일 형식
+    private static final Pattern EMAIL_PATTERN =
+            Pattern.compile("^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$");
+    private static final int MAX_NAME_LENGTH = 100;
+
+    @Column(name = "recipient_name", nullable = false, length = MAX_NAME_LENGTH)
+    private String name;
+
+    @Column(name = "recipient_slack_id", nullable = false, length = 100)
+    private String slackId;
+
+    private Recipient(String name, String slackId) {
+        validateName(name);
+        validateSlackId(slackId);
+        this.name = name;
+        this.slackId = slackId;
+    }
+
+    public static Recipient of(String name, String slackId) {
+        return new Recipient(name, slackId);
+    }
+
+    private static void validateName(String name) {
+        if (name == null || name.isBlank()) {
+            throw new IllegalArgumentException("수령인 이름은 필수입니다");
+        }
+        if (name.length() > MAX_NAME_LENGTH) {
+            throw new IllegalArgumentException(
+                    String.format("수령인 이름은 %d자 이하여야 합니다", MAX_NAME_LENGTH));
+        }
+    }
+
+    private static void validateSlackId(String slackId) {
+        if (slackId == null || slackId.isBlank()) {
+            throw new IllegalArgumentException("수령인 슬랙 ID는 필수입니다");
+        }
+        if (!EMAIL_PATTERN.matcher(slackId).matches()) {
+            throw new IllegalArgumentException("올바른 이메일 형식의 Slack ID가 아닙니다: " + slackId);
+        }
+    }
+}

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/domain/repository/DeliveryManagerRepository.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/domain/repository/DeliveryManagerRepository.java
@@ -5,6 +5,7 @@ import com.luckylogistics.delivery.domain.model.DeliveryManagerType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -24,4 +25,8 @@ public interface DeliveryManagerRepository {
             DeliveryManagerType type,
             UUID hubId
     );
+
+    List<DeliveryManager> findCompanyDeliveryManagersByHubId(UUID hubId);
+
+    List<DeliveryManager> findHubDeliveryManagers();
 }

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/domain/repository/DeliveryRepository.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/domain/repository/DeliveryRepository.java
@@ -14,6 +14,8 @@ public interface DeliveryRepository {
 
     Optional<Delivery> findById(UUID id);
 
+    Optional<Delivery> findByIdWithCompanyManager(UUID id);
+
     Optional<Delivery> findByIdWithRoutes(UUID id);
 
     boolean existsByOrderId(UUID orderId);

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/domain/repository/DeliveryRepository.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/domain/repository/DeliveryRepository.java
@@ -1,6 +1,9 @@
 package com.luckylogistics.delivery.domain.repository;
 
 import com.luckylogistics.delivery.domain.model.Delivery;
+import com.luckylogistics.delivery.domain.model.DeliveryStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -16,4 +19,18 @@ public interface DeliveryRepository {
     boolean existsByOrderId(UUID orderId);
 
     Optional<Delivery> findLastDeliveryByArrivalHubId(UUID hubId);
+
+    Page<Delivery> searchDeliveries(DeliveryStatus status, UUID departureHubId, UUID arrivalHubId, Pageable pageable);
+
+    Page<Delivery> searchByHubId(UUID hubId, Pageable pageable);
+
+    /**
+     * 업체 배송 담당자가 담당하는 배송 조회
+     */
+    Page<Delivery> searchByCompanyDeliveryManagerUserId(Long userId, Pageable pageable);
+
+    /**
+     * 허브 배송 담당자가 담당하는 배송 조회
+     */
+    Page<Delivery> searchByHubDeliveryManagerUserId(Long userId, Pageable pageable);
 }

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/domain/repository/DeliveryRepository.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/domain/repository/DeliveryRepository.java
@@ -9,6 +9,8 @@ public interface DeliveryRepository {
 
     Delivery save(Delivery delivery);
 
+    Optional<Delivery> findById(UUID id);
+
     boolean existsByOrderId(UUID orderId);
 
     Optional<Delivery> findLastDeliveryByArrivalHubId(UUID hubId);

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/domain/repository/DeliveryRepository.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/domain/repository/DeliveryRepository.java
@@ -11,6 +11,8 @@ public interface DeliveryRepository {
 
     Optional<Delivery> findById(UUID id);
 
+    Optional<Delivery> findByIdWithRoutes(UUID id);
+
     boolean existsByOrderId(UUID orderId);
 
     Optional<Delivery> findLastDeliveryByArrivalHubId(UUID hubId);

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/domain/repository/DeliveryRepository.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/domain/repository/DeliveryRepository.java
@@ -1,0 +1,15 @@
+package com.luckylogistics.delivery.domain.repository;
+
+import com.luckylogistics.delivery.domain.model.Delivery;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface DeliveryRepository {
+
+    Delivery save(Delivery delivery);
+
+    boolean existsByOrderId(UUID orderId);
+
+    Optional<Delivery> findLastDeliveryByArrivalHubId(UUID hubId);
+}

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/domain/repository/DeliveryRepository.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/domain/repository/DeliveryRepository.java
@@ -22,15 +22,22 @@ public interface DeliveryRepository {
 
     Page<Delivery> searchDeliveries(DeliveryStatus status, UUID departureHubId, UUID arrivalHubId, Pageable pageable);
 
-    Page<Delivery> searchByHubId(UUID hubId, Pageable pageable);
+    // 허브 관리자용: 배송 경로에 해당 허브가 포함된 배송 검색 + 필터
+    //(출발/도착/경유 허브 모두 포함)
+    Page<Delivery> searchByHubIdIncludingRoutes(
+            UUID hubId,
+            DeliveryStatus status,
+            UUID departureHubId,
+            UUID arrivalHubId,
+            Pageable pageable
+    );
 
-    /**
-     * 업체 배송 담당자가 담당하는 배송 조회
-     */
-    Page<Delivery> searchByCompanyDeliveryManagerUserId(Long userId, Pageable pageable);
-
-    /**
-     * 허브 배송 담당자가 담당하는 배송 조회
-     */
-    Page<Delivery> searchByHubDeliveryManagerUserId(Long userId, Pageable pageable);
+    // 배송 담당자용: 업체 배송 담당자 / 허브 배송 담당자 검색 + 필터
+    Page<Delivery> searchByDeliveryManagerUserId(
+            Long userId,
+            DeliveryStatus status,
+            UUID departureHubId,
+            UUID arrivalHubId,
+            Pageable pageable
+    );
 }

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/domain/repository/DeliveryRouteRepository.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/domain/repository/DeliveryRouteRepository.java
@@ -1,0 +1,16 @@
+package com.luckylogistics.delivery.domain.repository;
+
+import com.luckylogistics.delivery.domain.model.DeliveryRoute;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface DeliveryRouteRepository {
+
+    DeliveryRoute save(DeliveryRoute deliveryRoute);
+
+    List<DeliveryRoute> findByDeliveryIdOrderBySequence(UUID deliveryId);
+
+    Optional<DeliveryRoute> findLastDeliveryRoute();
+}

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/domain/service/DeliveryDomainService.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/domain/service/DeliveryDomainService.java
@@ -1,11 +1,18 @@
 package com.luckylogistics.delivery.domain.service;
 
+import com.luckylogistics.delivery.domain.model.Delivery;
+import com.luckylogistics.delivery.domain.model.DeliveryManager;
 import com.luckylogistics.delivery.domain.model.DeliveryManagerType;
+import com.luckylogistics.delivery.domain.model.DeliveryRoute;
 import com.luckylogistics.delivery.domain.repository.DeliveryManagerRepository;
+import com.luckylogistics.delivery.domain.repository.DeliveryRepository;
+import com.luckylogistics.delivery.domain.repository.DeliveryRouteRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.UUID;
 
 /**
@@ -14,9 +21,13 @@ import java.util.UUID;
 @Slf4j
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class DeliveryDomainService {
 
-    private final DeliveryManagerRepository repository;
+    private final DeliveryManagerRepository managerRepository;
+    private final DeliveryRepository deliveryRepository;
+    private final DeliveryRouteRepository routeRepository;
+
 
     /**
      * 다음 배송 순번 계산
@@ -26,7 +37,7 @@ public class DeliveryDomainService {
      */
     public Integer calculateNextSequence(DeliveryManagerType type, UUID hubId) {
         if (type == DeliveryManagerType.HUB_DELIVERY) {
-            return repository.findMaxSequenceByType(type)
+            return managerRepository.findMaxSequenceByType(type)
                     .map(maxSeq -> maxSeq + 1)
                     .orElse(0);
         } else {
@@ -34,7 +45,7 @@ public class DeliveryDomainService {
                 throw new IllegalArgumentException(
                         "업체 배송 담당자는 Hub ID가 필요합니다");
             }
-            return repository.findMaxSequenceByTypeAndHubId(type, hubId)
+            return managerRepository.findMaxSequenceByTypeAndHubId(type, hubId)
                     .map(maxSeq -> maxSeq + 1)
                     .orElse(0);
         }
@@ -45,9 +56,100 @@ public class DeliveryDomainService {
      * - 한 사용자는 하나의 배송 담당자만 등록 가능
      */
     public void validateNotDuplicate(Long deliveryManagerId) {
-        if (repository.existsById(deliveryManagerId)) {
+        if (managerRepository.existsById(deliveryManagerId)) {
             throw new IllegalStateException(
                     "이미 배송 담당자로 등록된 사용자입니다. deliveryManagerId: " + deliveryManagerId);
         }
+    }
+
+    /**
+     * 업체 배송 담당자 순차 배정
+     * - 해당 허브의 활성 업체 배송 담당자 목록 조회 (deliverySequence 오름차순)
+     * - 해당 허브의 마지막 배송 조회
+     * - 마지막 배송의 담당자 다음 순번 담당자 배정
+     * - 마지막 배송이 없으면 첫 번째 담당자 배정
+     */
+    public DeliveryManager assignCompanyDeliveryManager(UUID hubId) {
+        // 활성 담당자 목록 조회
+        List<DeliveryManager> managers = managerRepository.findCompanyDeliveryManagersByHubId(hubId);
+
+        if (managers.isEmpty()) {
+            throw new IllegalArgumentException("해당 허브에 업체 배송 담당자가 없습니다");
+        }
+
+        // 마지막 배정된 담당자 찾기
+        DeliveryManager lastAssignedManager = findLastAssignedCompanyManager(hubId, managers);
+
+        // 다음 순번 담당자 선택
+        return selectNextManager(managers, lastAssignedManager);
+    }
+
+    /**
+     * 허브 배송 담당자 순차 배정
+     * - 전체 허브 배송 담당자 목록 조회 (deliverySequence 오름차순)
+     * - 마지막 배송 경로 조회
+     * - 마지막 배송 경로의 담당자 다음 순번 담당자 배정
+     * - 마지막 배송 경로가 없으면 첫 번째 담당자 배정
+     */
+    public DeliveryManager assignHubDeliveryManager() {
+
+        // 활성 담당자 목록 조회
+        List<DeliveryManager> managers = managerRepository.findHubDeliveryManagers();
+
+        if (managers.isEmpty()) {
+            throw new IllegalArgumentException("허브 배송 담당자가 없습니다");
+        }
+
+        // 마지막 배정된 담당자 찾기
+        DeliveryManager lastAssignedManager = findLastAssignedHubManager(managers);
+
+        // 다음 순번 담당자 선택
+        return selectNextManager(managers, lastAssignedManager);
+    }
+
+    /**
+     * 마지막 배정된 업체 배송 담당자 찾기
+     */
+    private DeliveryManager findLastAssignedCompanyManager(UUID hubId, List<DeliveryManager> managers) {
+        return deliveryRepository.findLastDeliveryByArrivalHubId(hubId)
+                .map(Delivery::getCompanyDeliveryManager)
+                .filter(managers::contains)
+                .orElse(null);
+    }
+
+    /**
+     * 마지막 배정된 허브 배송 담당자 찾기
+     */
+    private DeliveryManager findLastAssignedHubManager(List<DeliveryManager> managers) {
+        return routeRepository.findLastDeliveryRoute()
+                .map(DeliveryRoute::getHubDeliveryManager)
+                .filter(managers::contains)
+                .orElse(null);
+    }
+
+    /**
+     * 다음 담당자 선택 (Round-Robin)
+     *
+     * @param managers 활성 담당자 목록 (deliverySequence 오름차순 정렬)
+     * @param lastAssigned 마지막 배정된 담당자 (null이면 첫 번째 담당자 반환)
+     * @return 다음 배정할 담당자
+     */
+    private DeliveryManager selectNextManager(List<DeliveryManager> managers, DeliveryManager lastAssigned) {
+        if (lastAssigned == null) {
+            // 첫 배정이거나 마지막 담당자가 삭제된 경우
+            return managers.get(0);
+        }
+
+        // 마지막 담당자의 인덱스 찾기
+        int lastIndex = managers.indexOf(lastAssigned);
+
+        if (lastIndex == -1) {
+            // 마지막 담당자가 리스트에 없으면 (삭제됨) 첫 번째 담당자
+            return managers.get(0);
+        }
+
+        // 다음 인덱스 계산 (Round-Robin)
+        int nextIndex = (lastIndex + 1) % managers.size();
+        return managers.get(nextIndex);
     }
 }

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/infrastructure/client/HubAdapter.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/infrastructure/client/HubAdapter.java
@@ -1,18 +1,24 @@
 package com.luckylogistics.delivery.infrastructure.client;
 
+import com.luckylogistics.delivery.application.dto.DeliveryRoutePlan;
 import com.luckylogistics.delivery.application.service.HubService;
+import com.luckylogistics.delivery.infrastructure.client.dto.HubRouteResponse;
+import com.luckylogistics.delivery.infrastructure.client.dto.HubRoutePlanResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+import java.math.BigDecimal;
+import java.util.List;
 import java.util.UUID;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class HubAdapter implements HubService {
+
     // TODO: 외부 서비스 클라이언트 주입
-    // private final HubFeignClient hubFeignClient;
+    // private final HubFeignClient hubClient;
 
     /**
      * 허브 존재 여부 검증
@@ -39,5 +45,46 @@ public class HubAdapter implements HubService {
         log.warn("[TODO] Hub Service 연동 필요 - hubId 하드코딩: {}", tempHubId);
         return tempHubId;
     }
-}
 
+    @Override
+    public DeliveryRoutePlan getDeliveryRoutePlan(UUID departureHubId, UUID arrivalHubId) {
+        // TODO: Hub Service 연동
+        // FIXME: 임시 하드코딩 (Hub Service 연동 시 제거 예정)
+        List<HubRouteResponse> tempRoutes = List.of(
+                HubRouteResponse.of(
+                        1,
+                        UUID.fromString("00000000-0000-0000-0000-000000000001"),
+                        UUID.fromString("00000000-0000-0000-0000-000000000002"),
+                        new BigDecimal("12.5"),
+                        18
+                ),
+                HubRouteResponse.of(
+                        2,
+                        UUID.fromString("00000000-0000-0000-0000-000000000002"),
+                        UUID.fromString("00000000-0000-0000-0000-000000000003"),
+                        new BigDecimal("8.7"),
+                        12
+                )
+        );
+
+        // 총 거리 계산 (BigDecimal)
+        BigDecimal tempTotalDistance = tempRoutes.stream()
+                .map(HubRouteResponse::distanceKm)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        // 총 소요 시간 계산
+        int tempTotalDuration = tempRoutes.stream()
+                .mapToInt(HubRouteResponse::durationMinutes)
+                .sum();
+
+        // 응답 객체 생성
+        // HubRoutePlanResponse response = hubClient.getLatestRoutePlan(departureHubId, arrivalHubId);
+        HubRoutePlanResponse tempResponse = HubRoutePlanResponse.of(tempRoutes, tempTotalDistance, tempTotalDuration);
+
+        log.warn("[TODO] Hub Service 연동 필요 - departureHubId={}, arrivalHubId={}, totalDistance={}km, totalDuration={}min",
+                departureHubId, arrivalHubId, tempTotalDistance, tempTotalDuration);
+
+        return tempResponse.toDeliveryRoutePlan();
+        // return hubClient.calculateRoute(request);
+    }
+}

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/infrastructure/client/HubFeignClient.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/infrastructure/client/HubFeignClient.java
@@ -1,13 +1,28 @@
 package com.luckylogistics.delivery.infrastructure.client;
 
 import com.luckylogistics.delivery.infrastructure.client.dto.HubResponse;
+import com.luckylogistics.delivery.infrastructure.client.dto.HubRoutePlanResponse;
 import org.springframework.cloud.openfeign.FeignClient;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
 
 // TODO: Hub Service 연동
 @FeignClient(name = "hub")
 public interface HubFeignClient {
+
+    /**
+     * 허브 단건 조회
+     */
     @GetMapping("/api/v1/hubs/{hubId}")
-    HubResponse getHub(@PathVariable("hubId") String hubId);
+    HubResponse getHub(@PathVariable("hubId") UUID hubId);
+
+    /**
+     * 배송 경로 조회
+     */
+    @GetMapping("/api/v1/hub-routes")
+    HubRoutePlanResponse getRoutePlan(
+            @RequestParam("from") UUID departureHubId,
+            @RequestParam("to") UUID arrivalHubId
+    );
 }

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/infrastructure/client/OrderAdapter.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/infrastructure/client/OrderAdapter.java
@@ -1,0 +1,39 @@
+package com.luckylogistics.delivery.infrastructure.client;
+
+import com.luckylogistics.delivery.application.service.OrderService;
+import com.luckylogistics.delivery.infrastructure.client.dto.OrderResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+class OrderAdapter implements OrderService {
+
+    // TODO: 외부 서비스 클라이언트 주입
+    // private final OrderFeignClient orderClient;
+
+    /**
+     * 주문 존재 여부 검증
+     */
+    @Override
+    public void validateOrderExists(UUID orderId) {
+        // TODO: Order Service 연동
+        // OrderResponse response = orderClient.getOrder(orderId);
+        // FIXME: 임시 하드코딩
+        OrderResponse response = OrderResponse.of(
+                orderId,
+                UUID.fromString("11111111-1111-1111-1111-111111111111"),
+                UUID.fromString("22222222-2222-2222-2222-222222222222")
+        );
+        response.validate();
+
+        log.debug("[Order] 주문 존재 확인 완료. orderId: {}, supplierCompanyId: {}, customerCompanyId: {}",
+                response.orderId(), response.supplierCompanyId(), response.customerCompanyId());
+
+        log.warn("[TODO] Order Service 연동 필요 - 임시 하드코딩 응답 반환");
+    }
+}

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/infrastructure/client/OrderFeignClient.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/infrastructure/client/OrderFeignClient.java
@@ -1,0 +1,15 @@
+package com.luckylogistics.delivery.infrastructure.client;
+
+import com.luckylogistics.delivery.infrastructure.client.dto.OrderResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import java.util.UUID;
+
+@FeignClient(name = "order")
+public interface OrderFeignClient {
+
+    @GetMapping("/api/v1/orders/{orderId}")
+    OrderResponse getOrder(@PathVariable("orderId") UUID orderId);
+}

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/infrastructure/client/dto/HubResponse.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/infrastructure/client/dto/HubResponse.java
@@ -1,11 +1,21 @@
 package com.luckylogistics.delivery.infrastructure.client.dto;
 
+import java.util.UUID;
+
 // TODO: Hub Service 연동
 public record HubResponse(
-        String hubId,
+        UUID hubId,
         String name,
         String address,
         Double latitude,
         Double longitude
 ) {
+    public void validate() {
+        if (hubId == null) {
+            throw new IllegalStateException("[HubClient] hubId가 유효하지 않습니다");
+        }
+        if (name == null || name.isBlank()) {
+            throw new IllegalStateException("[HubClient] name이 유효하지 않습니다");
+        }
+    }
 }

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/infrastructure/client/dto/HubRoutePlanResponse.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/infrastructure/client/dto/HubRoutePlanResponse.java
@@ -1,0 +1,66 @@
+package com.luckylogistics.delivery.infrastructure.client.dto;
+
+import com.luckylogistics.delivery.application.dto.DeliveryRoutePlan;
+import com.luckylogistics.delivery.application.dto.DeliveryRouteSegment;
+import lombok.Builder;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+// TODO: Hub Service 연동
+@Builder
+public record HubRoutePlanResponse(
+        List<HubRouteResponse> routes,
+        BigDecimal totalDistance,
+        Integer totalDuration
+) {
+    public HubRoutePlanResponse {
+        routes = routes == null ? List.of() : List.copyOf(routes);
+    }
+
+    public static HubRoutePlanResponse of(
+            List<HubRouteResponse> routes,
+            BigDecimal totalDistance,
+            Integer totalDuration
+    ) {
+        HubRoutePlanResponse response = HubRoutePlanResponse.builder()
+                .routes(routes)
+                .totalDistance(totalDistance)
+                .totalDuration(totalDuration)
+                .build();
+
+        response.validate();
+        return response;
+    }
+
+    public void validate() {
+        if (routes.isEmpty())
+            throw new IllegalArgumentException("[HubClient] routes는 비어 있을 수 없습니다.");
+
+        if (totalDistance == null || totalDistance.compareTo(BigDecimal.ZERO) <= 0)
+            throw new IllegalArgumentException("[HubClient] totalDistance는 0보다 커야 합니다.");
+
+        if (totalDuration == null || totalDuration <= 0)
+            throw new IllegalArgumentException("[HubClient] totalDuration은 0보다 커야 합니다.");
+
+        for (HubRouteResponse route : routes)
+            route.validate();
+    }
+
+    /**
+     * application DeliveryRoutePlan 으로 변환
+     */
+    public DeliveryRoutePlan toDeliveryRoutePlan() {
+        List<DeliveryRouteSegment> segments = routes.stream()
+                .map(r -> DeliveryRouteSegment.of(
+                        r.sequence(),
+                        r.departureHubId(),
+                        r.arrivalHubId(),
+                        r.distanceKm(),
+                        r.durationMinutes()
+                ))
+                .toList();
+
+        return DeliveryRoutePlan.of(segments, totalDistance, totalDuration);
+    }
+}

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/infrastructure/client/dto/HubRouteResponse.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/infrastructure/client/dto/HubRouteResponse.java
@@ -1,0 +1,51 @@
+package com.luckylogistics.delivery.infrastructure.client.dto;
+
+import lombok.Builder;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+// TODO: Hub Service 연동
+@Builder
+public record HubRouteResponse(
+        Integer sequence,
+        UUID departureHubId,
+        UUID arrivalHubId,
+        BigDecimal distanceKm,
+        Integer durationMinutes
+) {
+    public static HubRouteResponse of(
+            int sequence,
+            UUID departureHubId,
+            UUID arrivalHubId,
+            BigDecimal distanceKm,
+            int durationMinutes
+    ) {
+        HubRouteResponse hubRouteResponse = HubRouteResponse.builder()
+                .sequence(sequence)
+                .departureHubId(departureHubId)
+                .arrivalHubId(arrivalHubId)
+                .distanceKm(distanceKm)
+                .durationMinutes(durationMinutes)
+                .build();
+        hubRouteResponse.validate();
+        return hubRouteResponse;
+    }
+
+    public void validate() {
+        if (sequence == null || sequence < 1)
+            throw new IllegalArgumentException("[HubClient] 경로 sequence는 1 이상의 값이어야 합니다.");
+
+        if (departureHubId == null)
+            throw new IllegalArgumentException("[HubClient] 출발 hubId는 필수입니다.");
+
+        if (arrivalHubId == null)
+            throw new IllegalArgumentException("[HubClient] 도착 hubId는 필수입니다.");
+
+        if (distanceKm == null || distanceKm.compareTo(BigDecimal.ZERO) <= 0)
+            throw new IllegalArgumentException("[HubClient] distanceKm은 0보다 커야 합니다.");
+
+        if (durationMinutes == null || durationMinutes <= 0)
+            throw new IllegalArgumentException("[HubClient] durationMinutes는 0보다 커야 합니다.");
+    }
+}

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/infrastructure/client/dto/OrderResponse.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/infrastructure/client/dto/OrderResponse.java
@@ -1,0 +1,36 @@
+package com.luckylogistics.delivery.infrastructure.client.dto;
+
+import lombok.Builder;
+
+import java.util.UUID;
+
+// TODO: Order Service 연동
+@Builder
+public record OrderResponse(
+        UUID orderId,             // 주문 ID
+        UUID supplierCompanyId,   // 공급업체 ID
+        UUID customerCompanyId    // 수령업체 ID
+) {
+    /**
+     * 응답 데이터 유효성 검증
+     */
+    public void validate() {
+        if (orderId == null) {
+            throw new IllegalStateException("[OrderClient] orderId가 유효하지 않습니다");
+        }
+        if (supplierCompanyId == null) {
+            throw new IllegalStateException("[OrderClient] supplierCompanyId가 유효하지 않습니다");
+        }
+        if (customerCompanyId == null) {
+            throw new IllegalStateException("[OrderClient] customerCompanyId가 유효하지 않습니다");
+        }
+    }
+
+    public static OrderResponse of(UUID orderId, UUID supplierCompanyId, UUID customerCompanyId) {
+        return OrderResponse.builder()
+                .orderId(orderId)
+                .supplierCompanyId(supplierCompanyId)
+                .customerCompanyId(customerCompanyId)
+                .build();
+    }
+}

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/infrastructure/client/dto/UserResponse.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/infrastructure/client/dto/UserResponse.java
@@ -5,9 +5,6 @@ import com.luckylogistics.delivery.common.enums.UserRole;
 // TODO: User Service 연동
 public record UserResponse(
         Long userId,
-        String username,
-        String slackId,
-        UserRole role,
-        String hubId
+        UserRole role
 ) {
 }

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/infrastructure/repository/DeliveryManagerRepositoryImpl.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/infrastructure/repository/DeliveryManagerRepositoryImpl.java
@@ -9,6 +9,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -55,5 +56,15 @@ public class DeliveryManagerRepositoryImpl implements DeliveryManagerRepository 
             UUID hubId
     ) {
         return jpaRepository.findMaxSequenceByTypeAndHubId(type, hubId);
+    }
+
+    @Override
+    public List<DeliveryManager> findCompanyDeliveryManagersByHubId(UUID hubId) {
+        return jpaRepository.findCompanyDeliveryManagersByHubId(hubId);
+    }
+
+    @Override
+    public List<DeliveryManager> findHubDeliveryManagers() {
+        return jpaRepository.findHubDeliveryManagers();
     }
 }

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/infrastructure/repository/DeliveryRepositoryImpl.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/infrastructure/repository/DeliveryRepositoryImpl.java
@@ -51,17 +51,26 @@ public class DeliveryRepositoryImpl implements DeliveryRepository {
     }
 
     @Override
-    public Page<Delivery> searchByHubId(UUID hubId, Pageable pageable) {
-        return jpaRepository.searchByHubId(hubId, pageable);
+    public Page<Delivery> searchByHubIdIncludingRoutes(
+            UUID hubId,
+            DeliveryStatus status,
+            UUID departureHubId,
+            UUID arrivalHubId,
+            Pageable pageable
+    ) {
+        return jpaRepository.searchByHubIdIncludingRoutes(
+                hubId, status, departureHubId, arrivalHubId, pageable);
     }
 
     @Override
-    public Page<Delivery> searchByCompanyDeliveryManagerUserId(Long userId, Pageable pageable) {
-        return jpaRepository.searchByCompanyDeliveryManagerUserId(userId, pageable);
-    }
-
-    @Override
-    public Page<Delivery> searchByHubDeliveryManagerUserId(Long userId, Pageable pageable) {
-        return jpaRepository.searchByHubDeliveryManagerUserId(userId, pageable);
+    public Page<Delivery> searchByDeliveryManagerUserId(
+            Long userId,
+            DeliveryStatus status,
+            UUID departureHubId,
+            UUID arrivalHubId,
+            Pageable pageable
+    ) {
+        return jpaRepository.searchByDeliveryManagerUserId(
+                userId, status, departureHubId, arrivalHubId, pageable);
     }
 }

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/infrastructure/repository/DeliveryRepositoryImpl.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/infrastructure/repository/DeliveryRepositoryImpl.java
@@ -1,8 +1,11 @@
 package com.luckylogistics.delivery.infrastructure.repository;
 
 import com.luckylogistics.delivery.domain.model.Delivery;
+import com.luckylogistics.delivery.domain.model.DeliveryStatus;
 import com.luckylogistics.delivery.domain.repository.DeliveryRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -40,5 +43,25 @@ public class DeliveryRepositoryImpl implements DeliveryRepository {
     @Override
     public Optional<Delivery> findLastDeliveryByArrivalHubId(UUID hubId) {
         return jpaRepository.findTopByArrivalHubIdAndDeletedAtIsNullOrderByCreatedAtDesc(hubId);
+    }
+
+    @Override
+    public Page<Delivery> searchDeliveries(DeliveryStatus status, UUID departureHubId, UUID arrivalHubId, Pageable pageable) {
+        return jpaRepository.searchDeliveries(status, departureHubId, arrivalHubId, pageable);
+    }
+
+    @Override
+    public Page<Delivery> searchByHubId(UUID hubId, Pageable pageable) {
+        return jpaRepository.searchByHubId(hubId, pageable);
+    }
+
+    @Override
+    public Page<Delivery> searchByCompanyDeliveryManagerUserId(Long userId, Pageable pageable) {
+        return jpaRepository.searchByCompanyDeliveryManagerUserId(userId, pageable);
+    }
+
+    @Override
+    public Page<Delivery> searchByHubDeliveryManagerUserId(Long userId, Pageable pageable) {
+        return jpaRepository.searchByHubDeliveryManagerUserId(userId, pageable);
     }
 }

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/infrastructure/repository/DeliveryRepositoryImpl.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/infrastructure/repository/DeliveryRepositoryImpl.java
@@ -28,6 +28,11 @@ public class DeliveryRepositoryImpl implements DeliveryRepository {
     }
 
     @Override
+    public Optional<Delivery> findByIdWithRoutes(UUID id) {
+        return jpaRepository.findByIdWithRoutes(id);
+    }
+
+    @Override
     public boolean existsByOrderId(UUID orderId) {
         return jpaRepository.existsByOrderIdAndDeletedAtIsNull(orderId);
     }

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/infrastructure/repository/DeliveryRepositoryImpl.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/infrastructure/repository/DeliveryRepositoryImpl.java
@@ -31,6 +31,11 @@ public class DeliveryRepositoryImpl implements DeliveryRepository {
     }
 
     @Override
+    public Optional<Delivery> findByIdWithCompanyManager(UUID id) {
+        return jpaRepository.findByIdWithCompanyManager(id);
+    }
+
+    @Override
     public Optional<Delivery> findByIdWithRoutes(UUID id) {
         return jpaRepository.findByIdWithRoutes(id);
     }

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/infrastructure/repository/DeliveryRepositoryImpl.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/infrastructure/repository/DeliveryRepositoryImpl.java
@@ -23,6 +23,11 @@ public class DeliveryRepositoryImpl implements DeliveryRepository {
     }
 
     @Override
+    public Optional<Delivery> findById(UUID id) {
+        return jpaRepository.findByDeliveryIdAndDeletedAtIsNull(id);
+    }
+
+    @Override
     public boolean existsByOrderId(UUID orderId) {
         return jpaRepository.existsByOrderIdAndDeletedAtIsNull(orderId);
     }

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/infrastructure/repository/DeliveryRepositoryImpl.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/infrastructure/repository/DeliveryRepositoryImpl.java
@@ -1,0 +1,34 @@
+package com.luckylogistics.delivery.infrastructure.repository;
+
+import com.luckylogistics.delivery.domain.model.Delivery;
+import com.luckylogistics.delivery.domain.repository.DeliveryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class DeliveryRepositoryImpl implements DeliveryRepository {
+
+    private final JpaDeliveryRepository jpaRepository;
+
+    @Override
+    @Transactional
+    public Delivery save(Delivery delivery) {
+        return jpaRepository.save(delivery);
+    }
+
+    @Override
+    public boolean existsByOrderId(UUID orderId) {
+        return jpaRepository.existsByOrderIdAndDeletedAtIsNull(orderId);
+    }
+
+    @Override
+    public Optional<Delivery> findLastDeliveryByArrivalHubId(UUID hubId) {
+        return jpaRepository.findTopByArrivalHubIdAndDeletedAtIsNullOrderByCreatedAtDesc(hubId);
+    }
+}

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/infrastructure/repository/DeliveryRouteRepositoryImpl.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/infrastructure/repository/DeliveryRouteRepositoryImpl.java
@@ -1,0 +1,35 @@
+package com.luckylogistics.delivery.infrastructure.repository;
+
+import com.luckylogistics.delivery.domain.model.DeliveryRoute;
+import com.luckylogistics.delivery.domain.repository.DeliveryRouteRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class DeliveryRouteRepositoryImpl implements DeliveryRouteRepository {
+
+    private final JpaDeliveryRouteRepository jpaRepository;
+
+    @Override
+    @Transactional
+    public DeliveryRoute save(DeliveryRoute deliveryRoute) {
+        return jpaRepository.save(deliveryRoute);
+    }
+
+    @Override
+    public List<DeliveryRoute> findByDeliveryIdOrderBySequence(UUID deliveryId) {
+        return jpaRepository.findByDeliveryIdOrderBySequence(deliveryId);
+    }
+
+    @Override
+    public Optional<DeliveryRoute> findLastDeliveryRoute() {
+        return jpaRepository.findTopByDeletedAtIsNullOrderByCreatedAtDesc();
+    }
+}

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/infrastructure/repository/JpaDeliveryManagerRepository.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/infrastructure/repository/JpaDeliveryManagerRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -48,4 +49,22 @@ public interface JpaDeliveryManagerRepository extends JpaRepository<DeliveryMana
             @Param("type") DeliveryManagerType type,
             @Param("hubId") UUID hubId
     );
+
+    // 허브별 업체 담당자 순서
+    @Query("""
+        SELECT dm FROM DeliveryManager dm
+        WHERE dm.hubId = :hubId
+          AND dm.type = 'COMPANY_DELIVERY'
+          AND dm.deletedAt IS NULL
+        ORDER BY dm.deliverySequence
+    """)
+    List<DeliveryManager> findCompanyDeliveryManagersByHubId(@Param("hubId") UUID hubId);
+
+    @Query("""
+        SELECT dm FROM DeliveryManager dm
+        WHERE dm.type = 'HUB_DELIVERY'
+          AND dm.deletedAt IS NULL
+        ORDER BY dm.deliverySequence
+    """)
+    List<DeliveryManager> findHubDeliveryManagers();
 }

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/infrastructure/repository/JpaDeliveryRepository.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/infrastructure/repository/JpaDeliveryRepository.java
@@ -1,0 +1,17 @@
+package com.luckylogistics.delivery.infrastructure.repository;
+
+import com.luckylogistics.delivery.domain.model.Delivery;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface JpaDeliveryRepository extends JpaRepository<Delivery, UUID> {
+
+    boolean existsByOrderIdAndDeletedAtIsNull(UUID orderId);
+
+    /**
+     * 특정 허브의 마지막 배송 조회 (업체 배송 담당자 배정용)
+     */
+    Optional<Delivery> findTopByArrivalHubIdAndDeletedAtIsNullOrderByCreatedAtDesc(UUID hubId);
+}

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/infrastructure/repository/JpaDeliveryRepository.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/infrastructure/repository/JpaDeliveryRepository.java
@@ -36,44 +36,75 @@ public interface JpaDeliveryRepository extends JpaRepository<Delivery, UUID> {
      */
     Optional<Delivery> findTopByArrivalHubIdAndDeletedAtIsNullOrderByCreatedAtDesc(UUID hubId);
 
+    /**
+     * 마스터/업체 관리자용 검색
+     */
     @Query("""
         SELECT d
           FROM Delivery d
+          JOIN FETCH d.companyDeliveryManager cdm
          WHERE d.deletedAt IS NULL
            AND (:status IS NULL OR d.status = :status)
-           AND (:dep IS NULL OR d.departureHubId = :dep)
-           AND (:arr IS NULL OR d.arrivalHubId = :arr)
+           AND (:departureHubId IS NULL OR d.departureHubId = :departureHubId)
+           AND (:arrivalHubId IS NULL OR d.arrivalHubId = :arrivalHubId)
     """)
     Page<Delivery> searchDeliveries(
             @Param("status") DeliveryStatus status,
-            @Param("dep") UUID departureHubId,
-            @Param("arr") UUID arrivalHubId,
+            @Param("departureHubId") UUID departureHubId,
+            @Param("arrivalHubId") UUID arrivalHubId,
             Pageable pageable
     );
 
+    /**
+     * 허브 관리자용: 출발/도착/경유 허브 확인 + 필터
+     * - d.departureHubId: 출발 허브
+     * - d.arrivalHubId: 도착 허브
+     * - EXISTS (routes): 경유 허브 (DeliveryRoute의 출발/도착 허브)
+     */
     @Query("""
-        SELECT d
-        FROM Delivery d
-        WHERE (d.departureHubId = :hubId OR d.arrivalHubId = :hubId)
-        AND d.deletedAt IS NULL
+        SELECT DISTINCT d
+          FROM Delivery d
+          JOIN FETCH d.companyDeliveryManager cdm
+          LEFT JOIN d.routes r
+        WHERE d.deletedAt IS NULL
+          AND (d.departureHubId = :hubId
+             OR d.arrivalHubId = :hubId
+             OR r.departureHubId = :hubId
+             OR r.arrivalHubId = :hubId)
+          AND (:status IS NULL OR d.status = :status)
+          AND (:departureHubId IS NULL OR d.departureHubId = :departureHubId)
+          AND (:arrivalHubId IS NULL OR d.arrivalHubId = :arrivalHubId)
     """)
-    Page<Delivery> searchByHubId(@Param("hubId") UUID hubId, Pageable pageable);
+    Page<Delivery> searchByHubIdIncludingRoutes(
+            @Param("hubId") UUID hubId,
+            @Param("status") DeliveryStatus status,
+            @Param("departureHubId") UUID departureHubId,
+            @Param("arrivalHubId") UUID arrivalHubId,
+            Pageable pageable
+    );
 
-    @Query("""
-        SELECT d
-        FROM Delivery d
-        JOIN FETCH d.companyDeliveryManager cdm
-        WHERE cdm.deliveryManagerId = :userId
-        AND d.deletedAt IS NULL
+    /**
+     * 배송 담당자용: 업체 배송 담당자 / 허브 배송 담당자 + 필터
+     * - companyDeliveryManager: 업체 배송 담당자
+     * - hubDeliveryManager: 허브 배송 담당자
+     */
+    @Query(value = """
+        SELECT DISTINCT d
+          FROM Delivery d
+          JOIN FETCH d.companyDeliveryManager cdm
+          LEFT JOIN d.routes r
+          LEFT JOIN r.hubDeliveryManager hdm
+         WHERE d.deletedAt IS NULL
+           AND (cdm.deliveryManagerId = :userId OR hdm.deliveryManagerId = :userId)
+           AND (:status IS NULL OR d.status = :status)
+           AND (:departureHubId IS NULL OR d.departureHubId = :departureHubId)
+           AND (:arrivalHubId IS NULL OR d.arrivalHubId = :arrivalHubId)
     """)
-    Page<Delivery> searchByCompanyDeliveryManagerUserId(@Param("userId") Long userId, Pageable pageable);
-
-    @Query("""
-        SELECT d
-        FROM Delivery d
-        JOIN FETCH d.routes dr
-        WHERE dr.hubDeliveryManager.deliveryManagerId = :userId
-        AND d.deletedAt IS NULL
-    """)
-    Page<Delivery> searchByHubDeliveryManagerUserId(@Param("userId") Long userId, Pageable pageable);
+    Page<Delivery> searchByDeliveryManagerUserId(
+            @Param("userId") Long userId,
+            @Param("status") DeliveryStatus status,
+            @Param("departureHubId") UUID departureHubId,
+            @Param("arrivalHubId") UUID arrivalHubId,
+            Pageable pageable
+    );
 }

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/infrastructure/repository/JpaDeliveryRepository.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/infrastructure/repository/JpaDeliveryRepository.java
@@ -8,6 +8,8 @@ import java.util.UUID;
 
 public interface JpaDeliveryRepository extends JpaRepository<Delivery, UUID> {
 
+    Optional<Delivery> findByDeliveryIdAndDeletedAtIsNull(UUID id);
+
     boolean existsByOrderIdAndDeletedAtIsNull(UUID orderId);
 
     /**

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/infrastructure/repository/JpaDeliveryRepository.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/infrastructure/repository/JpaDeliveryRepository.java
@@ -1,6 +1,9 @@
 package com.luckylogistics.delivery.infrastructure.repository;
 
 import com.luckylogistics.delivery.domain.model.Delivery;
+import com.luckylogistics.delivery.domain.model.DeliveryStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -32,4 +35,45 @@ public interface JpaDeliveryRepository extends JpaRepository<Delivery, UUID> {
      * 특정 허브의 마지막 배송 조회 (업체 배송 담당자 배정용)
      */
     Optional<Delivery> findTopByArrivalHubIdAndDeletedAtIsNullOrderByCreatedAtDesc(UUID hubId);
+
+    @Query("""
+        SELECT d
+          FROM Delivery d
+         WHERE d.deletedAt IS NULL
+           AND (:status IS NULL OR d.status = :status)
+           AND (:dep IS NULL OR d.departureHubId = :dep)
+           AND (:arr IS NULL OR d.arrivalHubId = :arr)
+    """)
+    Page<Delivery> searchDeliveries(
+            @Param("status") DeliveryStatus status,
+            @Param("dep") UUID departureHubId,
+            @Param("arr") UUID arrivalHubId,
+            Pageable pageable
+    );
+
+    @Query("""
+        SELECT d
+        FROM Delivery d
+        WHERE (d.departureHubId = :hubId OR d.arrivalHubId = :hubId)
+        AND d.deletedAt IS NULL
+    """)
+    Page<Delivery> searchByHubId(@Param("hubId") UUID hubId, Pageable pageable);
+
+    @Query("""
+        SELECT d
+        FROM Delivery d
+        JOIN FETCH d.companyDeliveryManager cdm
+        WHERE cdm.deliveryManagerId = :userId
+        AND d.deletedAt IS NULL
+    """)
+    Page<Delivery> searchByCompanyDeliveryManagerUserId(@Param("userId") Long userId, Pageable pageable);
+
+    @Query("""
+        SELECT d
+        FROM Delivery d
+        JOIN FETCH d.routes dr
+        WHERE dr.hubDeliveryManager.deliveryManagerId = :userId
+        AND d.deletedAt IS NULL
+    """)
+    Page<Delivery> searchByHubDeliveryManagerUserId(@Param("userId") Long userId, Pageable pageable);
 }

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/infrastructure/repository/JpaDeliveryRepository.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/infrastructure/repository/JpaDeliveryRepository.java
@@ -98,7 +98,7 @@ public interface JpaDeliveryRepository extends JpaRepository<Delivery, UUID> {
      * - companyDeliveryManager: 업체 배송 담당자
      * - hubDeliveryManager: 허브 배송 담당자
      */
-    @Query(value = """
+    @Query("""
         SELECT DISTINCT d
           FROM Delivery d
           JOIN FETCH d.companyDeliveryManager cdm

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/infrastructure/repository/JpaDeliveryRepository.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/infrastructure/repository/JpaDeliveryRepository.java
@@ -15,6 +15,15 @@ public interface JpaDeliveryRepository extends JpaRepository<Delivery, UUID> {
 
     Optional<Delivery> findByDeliveryIdAndDeletedAtIsNull(UUID id);
 
+    @Query("""
+        SELECT d
+          FROM Delivery d
+          LEFT JOIN FETCH d.companyDeliveryManager cdm
+         WHERE d.deletedAt IS NULL
+           AND d.deliveryId = :id
+    """)
+    Optional<Delivery> findByIdWithCompanyManager(@Param("id") UUID id);
+
     /**
      * 배송과 배송경로를 함께 조회
      */

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/infrastructure/repository/JpaDeliveryRepository.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/infrastructure/repository/JpaDeliveryRepository.java
@@ -21,6 +21,7 @@ public interface JpaDeliveryRepository extends JpaRepository<Delivery, UUID> {
     @Query("""
         SELECT DISTINCT d
         FROM Delivery d
+        LEFT JOIN FETCH d.companyDeliveryManager cdm
         LEFT JOIN FETCH d.routes r
         LEFT JOIN FETCH r.hubDeliveryManager m
         WHERE d.deliveryId = :id

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/infrastructure/repository/JpaDeliveryRepository.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/infrastructure/repository/JpaDeliveryRepository.java
@@ -2,6 +2,8 @@ package com.luckylogistics.delivery.infrastructure.repository;
 
 import com.luckylogistics.delivery.domain.model.Delivery;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -9,6 +11,20 @@ import java.util.UUID;
 public interface JpaDeliveryRepository extends JpaRepository<Delivery, UUID> {
 
     Optional<Delivery> findByDeliveryIdAndDeletedAtIsNull(UUID id);
+
+    /**
+     * 배송과 배송경로를 함께 조회
+     */
+    @Query("""
+        SELECT DISTINCT d
+        FROM Delivery d
+        LEFT JOIN FETCH d.routes r
+        LEFT JOIN FETCH r.hubDeliveryManager m
+        WHERE d.deliveryId = :id
+          AND d.deletedAt IS NULL
+        ORDER BY r.sequence
+    """)
+    Optional<Delivery> findByIdWithRoutes(@Param("id") UUID id);
 
     boolean existsByOrderIdAndDeletedAtIsNull(UUID orderId);
 

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/infrastructure/repository/JpaDeliveryRouteRepository.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/infrastructure/repository/JpaDeliveryRouteRepository.java
@@ -1,0 +1,26 @@
+package com.luckylogistics.delivery.infrastructure.repository;
+
+import com.luckylogistics.delivery.domain.model.DeliveryRoute;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface JpaDeliveryRouteRepository extends JpaRepository<DeliveryRoute, UUID> {
+
+    @Query("""
+        SELECT dr FROM DeliveryRoute dr
+        WHERE dr.delivery.deliveryId = :deliveryId
+          AND dr.deletedAt IS NULL
+        ORDER BY dr.sequence
+    """)
+    List<DeliveryRoute> findByDeliveryIdOrderBySequence(@Param("deliveryId") UUID deliveryId);
+
+    /**
+     * 마지막 배송 경로 조회 (허브 배송 담당자 배정용)
+     */
+    Optional<DeliveryRoute> findTopByDeletedAtIsNullOrderByCreatedAtDesc();
+}

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/infrastructure/repository/JpaDeliveryRouteRepository.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/infrastructure/repository/JpaDeliveryRouteRepository.java
@@ -13,7 +13,7 @@ public interface JpaDeliveryRouteRepository extends JpaRepository<DeliveryRoute,
 
     @Query("""
         SELECT dr FROM DeliveryRoute dr
-        WHERE dr.delivery.deliveryId = :deliveryId
+        WHERE dr.deliveryId = :deliveryId
           AND dr.deletedAt IS NULL
         ORDER BY dr.sequence
     """)

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/presentation/controller/DeliveryController.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/presentation/controller/DeliveryController.java
@@ -4,8 +4,11 @@ import com.luckylogistics.delivery.application.dto.*;
 import com.luckylogistics.delivery.application.service.DeliveryService;
 import com.luckylogistics.delivery.common.enums.UserRole;
 import com.luckylogistics.delivery.common.response.ApiResponse;
+import com.luckylogistics.delivery.domain.model.DeliveryStatus;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -64,5 +67,22 @@ public class DeliveryController {
     ) {
         deliveryService.deleteDelivery(deliveryId, currentUserId, currentUserRole);
         return ResponseEntity.ok(ApiResponse.success(null, "배송이 삭제되었습니다"));
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<Page<DeliverySummaryResponse>>> getDeliveries(
+            @RequestParam(required = false) DeliveryStatus status,
+            @RequestParam(required = false) UUID departureHubId,
+            @RequestParam(required = false) UUID arrivalHubId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(defaultValue = "createdAt") String sortBy,
+            @RequestParam(defaultValue = "DESC") Sort.Direction direction,
+            @RequestHeader("X-User-Id") Long currentUserId,
+            @RequestHeader("X-User-Role") UserRole currentUserRole
+    ) {
+        Page<DeliverySummaryResponse> response = deliveryService.getDeliveries(
+                status, departureHubId, arrivalHubId, page, size, sortBy, direction, currentUserId, currentUserRole);
+        return ResponseEntity.ok(ApiResponse.success(response, "배송 목록이 조회되었습니다"));
     }
 }

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/presentation/controller/DeliveryController.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/presentation/controller/DeliveryController.java
@@ -1,8 +1,6 @@
 package com.luckylogistics.delivery.presentation.controller;
 
-import com.luckylogistics.delivery.application.dto.CreateDeliveryRequest;
-import com.luckylogistics.delivery.application.dto.CreateDeliveryResponse;
-import com.luckylogistics.delivery.application.dto.DeliveryResponse;
+import com.luckylogistics.delivery.application.dto.*;
 import com.luckylogistics.delivery.application.service.DeliveryService;
 import com.luckylogistics.delivery.common.enums.UserRole;
 import com.luckylogistics.delivery.common.response.ApiResponse;
@@ -44,5 +42,17 @@ public class DeliveryController {
     ) {
         DeliveryResponse response = deliveryService.getDelivery(deliveryId, currentUserId, currentUserRole);
         return ResponseEntity.ok(ApiResponse.success(response, "배송이 조회되었습니다"));
+    }
+
+    @PatchMapping("/{deliveryId}/status")
+    public ResponseEntity<ApiResponse<UpdateDeliveryResponse>> updateDeliveryStatus(
+            @PathVariable UUID deliveryId,
+            @Valid @RequestBody UpdateDeliveryStatusRequest request,
+            @RequestHeader("X-User-Id") Long currentUserId,
+            @RequestHeader("X-User-Role") UserRole currentUserRole
+    ) {
+        UpdateDeliveryResponse response = deliveryService.updateDeliveryStatus(
+                deliveryId, request, currentUserId, currentUserRole);
+        return ResponseEntity.ok(ApiResponse.success(response, "배송 상태가 변경되었습니다"));
     }
 }

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/presentation/controller/DeliveryController.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/presentation/controller/DeliveryController.java
@@ -47,7 +47,7 @@ public class DeliveryController {
         return ResponseEntity.ok(ApiResponse.success(response, "배송이 조회되었습니다"));
     }
 
-    @PatchMapping("/{deliveryId}/status")
+    @PutMapping("/{deliveryId}/status")
     public ResponseEntity<ApiResponse<UpdateDeliveryResponse>> updateDeliveryStatus(
             @PathVariable UUID deliveryId,
             @Valid @RequestBody UpdateDeliveryStatusRequest request,

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/presentation/controller/DeliveryController.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/presentation/controller/DeliveryController.java
@@ -2,13 +2,17 @@ package com.luckylogistics.delivery.presentation.controller;
 
 import com.luckylogistics.delivery.application.dto.CreateDeliveryRequest;
 import com.luckylogistics.delivery.application.dto.CreateDeliveryResponse;
+import com.luckylogistics.delivery.application.dto.DeliveryResponse;
 import com.luckylogistics.delivery.application.service.DeliveryService;
+import com.luckylogistics.delivery.common.enums.UserRole;
 import com.luckylogistics.delivery.common.response.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/v1/deliveries")
@@ -30,5 +34,15 @@ public class DeliveryController {
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .body(ApiResponse.success(response, "배송이 생성되었습니다"));
+    }
+
+    @GetMapping("/{deliveryId}")
+    public ResponseEntity<DeliveryResponse> getDelivery(
+            @PathVariable UUID deliveryId,
+            @RequestHeader("X-User-Id") Long currentUserId,
+            @RequestHeader("X-User-Role") UserRole currentUserRole
+    ) {
+        DeliveryResponse response = deliveryService.getDelivery(deliveryId, currentUserId, currentUserRole);
+        return ResponseEntity.ok(response);
     }
 }

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/presentation/controller/DeliveryController.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/presentation/controller/DeliveryController.java
@@ -37,12 +37,12 @@ public class DeliveryController {
     }
 
     @GetMapping("/{deliveryId}")
-    public ResponseEntity<DeliveryResponse> getDelivery(
+    public ResponseEntity<ApiResponse<DeliveryResponse>> getDelivery(
             @PathVariable UUID deliveryId,
             @RequestHeader("X-User-Id") Long currentUserId,
             @RequestHeader("X-User-Role") UserRole currentUserRole
     ) {
         DeliveryResponse response = deliveryService.getDelivery(deliveryId, currentUserId, currentUserRole);
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(ApiResponse.success(response, "배송이 조회되었습니다"));
     }
 }

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/presentation/controller/DeliveryController.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/presentation/controller/DeliveryController.java
@@ -55,4 +55,14 @@ public class DeliveryController {
                 deliveryId, request, currentUserId, currentUserRole);
         return ResponseEntity.ok(ApiResponse.success(response, "배송 상태가 변경되었습니다"));
     }
+
+    @DeleteMapping("/{deliveryId}")
+    public ResponseEntity<ApiResponse<Void>> deleteDelivery(
+            @PathVariable UUID deliveryId,
+            @RequestHeader("X-User-Id") Long currentUserId,
+            @RequestHeader("X-User-Role") UserRole currentUserRole
+    ) {
+        deliveryService.deleteDelivery(deliveryId, currentUserId, currentUserRole);
+        return ResponseEntity.ok(ApiResponse.success(null, "배송이 삭제되었습니다"));
+    }
 }

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/presentation/controller/DeliveryController.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/presentation/controller/DeliveryController.java
@@ -66,7 +66,7 @@ public class DeliveryController {
             @RequestHeader("X-User-Role") UserRole currentUserRole
     ) {
         deliveryService.deleteDelivery(deliveryId, currentUserId, currentUserRole);
-        return ResponseEntity.ok(ApiResponse.success(null, "배송이 삭제되었습니다"));
+        return ResponseEntity.ok(ApiResponse.success("배송이 삭제되었습니다"));
     }
 
     @GetMapping

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/presentation/controller/DeliveryController.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/presentation/controller/DeliveryController.java
@@ -1,0 +1,34 @@
+package com.luckylogistics.delivery.presentation.controller;
+
+import com.luckylogistics.delivery.application.dto.CreateDeliveryRequest;
+import com.luckylogistics.delivery.application.dto.CreateDeliveryResponse;
+import com.luckylogistics.delivery.application.service.DeliveryService;
+import com.luckylogistics.delivery.common.response.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/deliveries")
+@RequiredArgsConstructor
+public class DeliveryController {
+
+    private final DeliveryService deliveryService;
+
+    /**
+     * 배송 생성
+     * Order Service에서 주문 생성 시 자동 호출
+     */
+    @PostMapping
+    public ResponseEntity<ApiResponse<CreateDeliveryResponse>> createDelivery(
+            @Valid @RequestBody CreateDeliveryRequest request,
+            @RequestHeader("X-User-Id") Long currentUserId
+    ) {
+        CreateDeliveryResponse response = deliveryService.createDelivery(request, currentUserId);
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(ApiResponse.success(response, "배송이 생성되었습니다"));
+    }
+}

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/presentation/controller/DeliveryManagerController.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/presentation/controller/DeliveryManagerController.java
@@ -60,7 +60,7 @@ public class DeliveryManagerController {
      * 배송 담당자 수정
      * - X-User-Id, X-User-Role: 권한 검증 필요
      */
-    @PatchMapping("/{deliveryManagerId}")
+    @PutMapping("/{deliveryManagerId}")
     public ResponseEntity<ApiResponse<DeliveryManagerResponse>> updateDeliveryManager(
             @PathVariable Long deliveryManagerId,
             @Valid @RequestBody UpdateDeliveryManagerRequest request,

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/presentation/controller/DeliveryManagerController.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/presentation/controller/DeliveryManagerController.java
@@ -10,7 +10,6 @@ import com.luckylogistics.delivery.common.response.ApiResponse;
 import com.luckylogistics.delivery.domain.model.DeliveryManagerType;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.hibernate.annotations.Parameter;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
@@ -83,7 +82,7 @@ public class DeliveryManagerController {
             @RequestHeader("X-User-Role") UserRole currentUserRole
     ) {
         deliveryManagerService.deleteDeliveryManager(deliveryManagerId, currentUserId, currentUserRole);
-        return ResponseEntity.ok(ApiResponse.success(null, "배송 담당자가 삭제되었습니다"));
+        return ResponseEntity.ok(ApiResponse.success("배송 담당자가 삭제되었습니다"));
     }
 
     /**

--- a/delivery/delivery/src/main/resources/application-datasource.yml
+++ b/delivery/delivery/src/main/resources/application-datasource.yml
@@ -1,0 +1,16 @@
+spring:
+  datasource:
+    driver-class-name: org.postgresql.Driver
+    url: jdbc:postgresql://localhost:5432/luckylogistics?currentSchema=deliveries
+    username: luckyvicky
+    password: luckyvicky
+  jpa:
+    hibernate:
+      ddl-auto: update
+    open-in-view: false
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+        format_sql: true
+        show_sql: true
+        default_schema: deliveries

--- a/delivery/delivery/src/main/resources/application-eureka.yml
+++ b/delivery/delivery/src/main/resources/application-eureka.yml
@@ -1,0 +1,6 @@
+eureka:
+  client:
+    service-url:
+      defaultZone: http://localhost:8761/eureka/
+    register-with-eureka: true
+    fetch-registry: true

--- a/delivery/delivery/src/main/resources/application-zipkin.yml
+++ b/delivery/delivery/src/main/resources/application-zipkin.yml
@@ -1,0 +1,8 @@
+management:
+  zipkin:
+    tracing:
+      endpoint: http://localhost:9411/api/v2/spans
+  tracing:
+    enabled: true
+    sampling:
+      probability: 1.0

--- a/delivery/delivery/src/main/resources/application.yml
+++ b/delivery/delivery/src/main/resources/application.yml
@@ -4,18 +4,9 @@ server:
 spring:
   application:
     name: delivery
-  datasource:
-    driver-class-name: org.postgresql.Driver
-    url: jdbc:postgresql://localhost:5432/luckylogistics?currentSchema=deliveries
-    username: luckyvicky
-    password: luckyvicky
-  jpa:
-    hibernate:
-      ddl-auto: update
-    open-in-view: false
-    properties:
-      hibernate:
-        dialect: org.hibernate.dialect.PostgreSQLDialect
-        format_sql: true
-        show_sql: true
-        default_schema: deliveries
+
+  profiles:
+    include:
+      - datasource
+#      - eureka
+#      - zipkin


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [x] 리팩터링
- [ ] 환경 설정/빌드
- [ ] 기타

## ❗️ 관련 이슈 링크
Close #24 

## 📝 개요
- 배송 CRUD 및 목록 조회 기능 구현
  - 배송 생성 (배송 경로 함께 생성)
  - 배송 상태 수정
  - 배송 단건 조회
  - 배송 목록 조회 (검색 조건 포함)
  - 배송 삭제 (배송 경로 함께 삭제)

## 🔁 변경 사항
- 배송 도메인 `Delivery`, `DeliveryRoute` 추가
- 배송 CRUD 및 목록 조회 API 구현

## 👀 참고 사항
- Eureka, FeignClient 연동은 TODO로 남겨두었습니다.

## 👀 기타