### PR TITLE
Feature/delivery/#49 setup feign clients

### DIFF
--- a/delivery/delivery/build.gradle
+++ b/delivery/delivery/build.gradle
@@ -29,6 +29,7 @@ ext {
 }
 
 dependencies {
+	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/DeliveryApplication.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/DeliveryApplication.java
@@ -2,10 +2,12 @@ package com.luckylogistics.delivery;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @SpringBootApplication
 @EnableFeignClients
+@EnableDiscoveryClient
 public class DeliveryApplication {
 
 	public static void main(String[] args) {

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/DeliveryApplication.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/DeliveryApplication.java
@@ -2,8 +2,10 @@ package com.luckylogistics.delivery;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @SpringBootApplication
+@EnableFeignClients
 public class DeliveryApplication {
 
 	public static void main(String[] args) {

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/application/service/DeliveryManagerService.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/application/service/DeliveryManagerService.java
@@ -44,7 +44,7 @@ public class DeliveryManagerService {
     ) {
         log.info("[DeliveryManager] 배송 담당자 생성 시작. userId: {}, type: {}", request.deliveryManagerId(), request.type());
         // 외부 User 서비스: USER 도메인에서 배송 담당자 타입 검증
-        userService.validateDeliveryManagerRole(request.deliveryManagerId());
+        userService.validateUserIsDeliveryManager(request.deliveryManagerId());
         // 도메인 서비스: 중복 검증
         domainService.validateNotDuplicate(request.deliveryManagerId());
         // Hub ID 검증
@@ -113,7 +113,7 @@ public class DeliveryManagerService {
         }
 
         if (currentUserRole.isHubManager()) {
-            UUID hubId = hubService.getUserHubId(currentUserId);
+            UUID hubId = hubService.getHubByUserId(currentUserId);
 
             if (!manager.belongsToHub(hubId)) {
                 throw new BusinessException(ErrorCode.HUB_MANAGER_FORBIDDEN);
@@ -176,7 +176,7 @@ public class DeliveryManagerService {
         }
 
         if (currentUserRole.isHubManager()) {
-            UUID hubId = hubService.getUserHubId(currentUserId);
+            UUID hubId = hubService.getHubByUserId(currentUserId);
 
             if (!manager.belongsToHub(hubId)) {
                 throw new BusinessException(ErrorCode.HUB_MANAGER_FORBIDDEN);
@@ -276,7 +276,7 @@ public class DeliveryManagerService {
         }
 
         // 허브 관리자
-        UUID myHubId = hubService.getUserHubId(currentUserId);
+        UUID myHubId = hubService.getHubByUserId(currentUserId);
         if (myHubId == null) {
             throw new BusinessException(ErrorCode.USER_HUB_NOT_FOUND);
         }

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/application/service/DeliveryRouteService.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/application/service/DeliveryRouteService.java
@@ -92,7 +92,7 @@ public class DeliveryRouteService {
 
         // 허브 관리자: 담당 허브의 경로만 변경 가능
         if (currentUserRole.isHubManager()) {
-            UUID userHubId = hubService.getUserHubId(currentUserId);
+            UUID userHubId = hubService.getHubByUserId(currentUserId);
             if (!route.isRelatedToHub(userHubId)) {
                 throw new BusinessException(ErrorCode.FORBIDDEN_NOT_HUB_ROUTE);
             }
@@ -145,7 +145,7 @@ public class DeliveryRouteService {
 
         // 허브 관리자: 담당 허브의 경로만 조회 가능
         if (currentUserRole.isHubManager()) {
-            UUID userHubId = hubService.getUserHubId(currentUserId);
+            UUID userHubId = hubService.getHubByUserId(currentUserId);
 
             if (route != null && !route.isRelatedToHub(userHubId)) {
                 throw new BusinessException(ErrorCode.FORBIDDEN_NOT_HUB_ROUTE);

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/application/service/DeliveryService.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/application/service/DeliveryService.java
@@ -123,7 +123,7 @@ public class DeliveryService {
 
         // 허브 관리자: 배송의 출발/도착 허브, 경로에 포함된 모든 허브 관리자는 접근 가능
         if (currentUserRole.isHubManager()) {
-            UUID userHubId = hubService.getUserHubId(currentUserId);
+            UUID userHubId = hubService.getHubByUserId(currentUserId);
             boolean permitted =
                     delivery.isRelatedToHub(userHubId) ||
                             delivery.getRoutes().stream().anyMatch(r -> r.isRelatedToHub(userHubId));
@@ -183,7 +183,7 @@ public class DeliveryService {
 
         // 허브 관리자: 도착 허브 관리자만 허용
         if (currentUserRole.isHubManager()) {
-            UUID userHubId = hubService.getUserHubId(currentUserId);
+            UUID userHubId = hubService.getHubByUserId(currentUserId);
             if (!delivery.isArrivalHub(userHubId)) {
                 throw new BusinessException(ErrorCode.FORBIDDEN_DELIVERY_MODIFY);
             }
@@ -223,7 +223,7 @@ public class DeliveryService {
 
         // 허브 관리자: 본인 허브와 관련된 배송만 삭제 가능
         if (currentUserRole.isHubManager()) {
-            UUID userHubId = hubService.getUserHubId(currentUserId);
+            UUID userHubId = hubService.getHubByUserId(currentUserId);
             if (!delivery.isRelatedToHub(userHubId)) {
                 throw new BusinessException(ErrorCode.FORBIDDEN_DELIVERY_DELETE);
             }
@@ -275,7 +275,7 @@ public class DeliveryService {
 
         // 허브 관리자: 배송 경로에 내 허브가 포함된 배송만 조회 + 필터
         if (currentUserRole.isHubManager()) {
-            UUID userHubId = hubService.getUserHubId(currentUserId);
+            UUID userHubId = hubService.getHubByUserId(currentUserId);
             if (userHubId == null) {
                 throw new BusinessException(ErrorCode.FORBIDDEN_DELIVERY_SEARCH);
             }

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/application/service/HubService.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/application/service/HubService.java
@@ -15,7 +15,7 @@ public interface HubService {
      * 요청 사용자의 Hub ID 조회
      * HUB_MANAGER의 담당 허브 확인 (권한)
      */
-    UUID getUserHubId(Long userId);
+    UUID getHubByUserId(Long userId);
 
     /**
      * 배송 경로 조회

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/application/service/UserService.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/application/service/UserService.java
@@ -2,5 +2,5 @@ package com.luckylogistics.delivery.application.service;
 
 public interface UserService {
 
-    void validateDeliveryManagerRole(Long userId);
+    void validateUserIsDeliveryManager(Long userId);
 }

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/common/enums/OrderStatus.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/common/enums/OrderStatus.java
@@ -1,0 +1,6 @@
+package com.luckylogistics.delivery.common.enums;
+
+public enum OrderStatus {
+    DELETED, // 삭제
+    ORDERED; // 주문 완료
+}

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/common/enums/UserOrganizationType.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/common/enums/UserOrganizationType.java
@@ -1,0 +1,6 @@
+package com.luckylogistics.delivery.common.enums;
+
+public enum  UserOrganizationType {
+    HUB,
+    COMPANY;
+}

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/common/enums/UserStatus.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/common/enums/UserStatus.java
@@ -1,0 +1,7 @@
+package com.luckylogistics.delivery.common.enums;
+
+public enum  UserStatus {
+    PENDING,
+    APPROVED,
+    REJECTED
+}

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/common/exception/ErrorCode.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/common/exception/ErrorCode.java
@@ -14,6 +14,7 @@ public enum ErrorCode {
     FORBIDDEN(HttpStatus.FORBIDDEN, "D-003", "권한이 없습니다"),
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "D-003", "잘못된 요청입니다"),
     INVALID_HEADER_USER_ROLE(HttpStatus.BAD_REQUEST, "D-004", "잘못된 X-User-Role 헤더입니다"),
+    FEIGN_ERROR(HttpStatus.BAD_GATEWAY, "D-500", "외부 서비스 요청 중 오류가 발생했습니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "D-999", "서버 오류가 발생했습니다"),
 
     // DeliveryManager

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/common/exception/GlobalExceptionHandler.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/common/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.luckylogistics.delivery.common.exception;
 
 import com.luckylogistics.delivery.common.response.ApiResponse;
+import feign.FeignException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -83,6 +84,9 @@ public class GlobalExceptionHandler {
                 .body(ApiResponse.error(ErrorCode.INTERNAL_SERVER_ERROR));
     }
 
+    /**
+     * 잘못된 파라미터 타입 매핑 예외 처리
+     */
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)
     public ResponseEntity<ApiResponse<?>> handleTypeMismatch(MethodArgumentTypeMismatchException e) {
         if ("X-User-Role".equalsIgnoreCase(e.getName())) {
@@ -93,5 +97,18 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .badRequest()
                 .body(ApiResponse.error(ErrorCode.BAD_REQUEST, e.getMessage()));
+    }
+
+    /**
+     * FeignClient 통신 예외 처리
+     */
+    @ExceptionHandler(FeignException.class)
+    public ResponseEntity<ApiResponse<Void>> handleFeign(FeignException e) {
+        int status = e.status();
+        log.error("[Feign] status={} message={}", status, e.getMessage());
+
+        return ResponseEntity
+                .status(status)
+                .body(ApiResponse.error(ErrorCode.FEIGN_ERROR, e.getMessage()));
     }
 }

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/infrastructure/client/HubAdapter.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/infrastructure/client/HubAdapter.java
@@ -2,14 +2,12 @@ package com.luckylogistics.delivery.infrastructure.client;
 
 import com.luckylogistics.delivery.application.dto.DeliveryRoutePlan;
 import com.luckylogistics.delivery.application.service.HubService;
-import com.luckylogistics.delivery.infrastructure.client.dto.HubRouteResponse;
+import com.luckylogistics.delivery.infrastructure.client.dto.HubResponse;
 import com.luckylogistics.delivery.infrastructure.client.dto.HubRoutePlanResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
-import java.math.BigDecimal;
-import java.util.List;
 import java.util.UUID;
 
 @Slf4j
@@ -17,74 +15,34 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class HubAdapter implements HubService {
 
-    // TODO: 외부 서비스 클라이언트 주입
-    // private final HubFeignClient hubClient;
+     private final HubFeignClient hubClient;
 
-    /**
-     * 허브 존재 여부 검증
-     */
+    // 허브 존재 여부 검증
+    @Override
     public void validateHubExists(UUID hubId) {
-        // TODO: Hub Service 연동
         // 허브 존재 하는지
-        // HubResponse hub = hubClient.getHub(hubId);
-
-        log.warn("[TODO] Hub Service 연동 필요 - hubId 검증 생략: {}", hubId);
+        HubResponse response = hubClient.getHub(hubId).data();
+        response.validate();
+        log.debug("[HubClient] 허브 존재 확인 완료. hubId: {}", response.hubId());
     }
 
-    /**
-     * 요청 사용자의 Hub ID 조회
-     * HUB_MANAGER의 담당 허브 확인 (권한)
-     */
-    public UUID getUserHubId(Long userId) {
-        // TODO: Hub Service 연동
-        // HubManagerResponse manager = hubClient.getHubManager(userId);
-        // return manager.hubId();
-
-        // FIXME: 임시 하드코딩
-        UUID tempHubId = UUID.fromString("00000000-0000-0000-0000-000000000001");
-        log.warn("[TODO] Hub Service 연동 필요 - hubId 하드코딩: {}", tempHubId);
-        return tempHubId;
+    // 요청 사용자의 Hub ID 조회
+    // 허브 관리자의 담당 허브 확인 (권한)
+    @Override
+    public UUID getHubByUserId(Long userId) {
+        HubResponse response = hubClient.getHubByUserId(userId).data();
+        response.validate();
+        log.info("[HubClient] 사용자의 담당 허브 조회 완료. hubId: {}", response.hubId());
+        return response.hubId();
     }
 
+    // 배송 경로 계획 조회
+    // 출발/도착 허브 간 경로 정보를 Hub 서비스에서 조회
     @Override
     public DeliveryRoutePlan getDeliveryRoutePlan(UUID departureHubId, UUID arrivalHubId) {
-        // TODO: Hub Service 연동
-        // FIXME: 임시 하드코딩 (Hub Service 연동 시 제거 예정)
-        List<HubRouteResponse> tempRoutes = List.of(
-                HubRouteResponse.of(
-                        1,
-                        UUID.fromString("00000000-0000-0000-0000-000000000001"),
-                        UUID.fromString("00000000-0000-0000-0000-000000000002"),
-                        new BigDecimal("12.5"),
-                        18
-                ),
-                HubRouteResponse.of(
-                        2,
-                        UUID.fromString("00000000-0000-0000-0000-000000000002"),
-                        UUID.fromString("00000000-0000-0000-0000-000000000003"),
-                        new BigDecimal("8.7"),
-                        12
-                )
-        );
-
-        // 총 거리 계산 (BigDecimal)
-        BigDecimal tempTotalDistance = tempRoutes.stream()
-                .map(HubRouteResponse::distanceKm)
-                .reduce(BigDecimal.ZERO, BigDecimal::add);
-
-        // 총 소요 시간 계산
-        int tempTotalDuration = tempRoutes.stream()
-                .mapToInt(HubRouteResponse::durationMinutes)
-                .sum();
-
-        // 응답 객체 생성
-        // HubRoutePlanResponse response = hubClient.getLatestRoutePlan(departureHubId, arrivalHubId);
-        HubRoutePlanResponse tempResponse = HubRoutePlanResponse.of(tempRoutes, tempTotalDistance, tempTotalDuration);
-
-        log.warn("[TODO] Hub Service 연동 필요 - departureHubId={}, arrivalHubId={}, totalDistance={}km, totalDuration={}min",
-                departureHubId, arrivalHubId, tempTotalDistance, tempTotalDuration);
-
-        return tempResponse.toDeliveryRoutePlan();
-        // return hubClient.calculateRoute(request);
+        HubRoutePlanResponse response = hubClient.getHubRoutePlan(departureHubId, arrivalHubId).data();
+        response.validate();
+        log.info("[HubClient] 배송 경로 계획 조회 완료. departureHubId: {}, arrivalHubId: {}", departureHubId, arrivalHubId);
+        return response.toDeliveryRoutePlan();
     }
 }

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/infrastructure/client/HubFeignClient.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/infrastructure/client/HubFeignClient.java
@@ -1,5 +1,6 @@
 package com.luckylogistics.delivery.infrastructure.client;
 
+import com.luckylogistics.delivery.common.response.ApiResponse;
 import com.luckylogistics.delivery.infrastructure.client.dto.HubResponse;
 import com.luckylogistics.delivery.infrastructure.client.dto.HubRoutePlanResponse;
 import org.springframework.cloud.openfeign.FeignClient;
@@ -7,21 +8,20 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;
 
-// TODO: Hub Service 연동
-@FeignClient(name = "hub")
+@FeignClient(name = "hub", path = "/api/v1/hubs")
 public interface HubFeignClient {
 
-    /**
-     * 허브 단건 조회
-     */
-    @GetMapping("/api/v1/hubs/{hubId}")
-    HubResponse getHub(@PathVariable("hubId") UUID hubId);
+    // 허브 단건 조회
+    @GetMapping("/{hubId}")
+    ApiResponse<HubResponse> getHub(@PathVariable("hubId") UUID hubId);
 
-    /**
-     * 배송 경로 조회
-     */
-    @GetMapping("/api/v1/hub-routes")
-    HubRoutePlanResponse getRoutePlan(
+    // 사용자 id로 담당 허브 조회
+    @GetMapping("/manager/{userId}/hub")
+    ApiResponse<HubResponse> getHubByUserId(@PathVariable("userId") Long userId);
+
+    // 배송 경로 조회
+    @GetMapping("/routes")
+    ApiResponse<HubRoutePlanResponse> getHubRoutePlan(
             @RequestParam("from") UUID departureHubId,
             @RequestParam("to") UUID arrivalHubId
     );

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/infrastructure/client/OrderAdapter.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/infrastructure/client/OrderAdapter.java
@@ -13,27 +13,13 @@ import java.util.UUID;
 @RequiredArgsConstructor
 class OrderAdapter implements OrderService {
 
-    // TODO: 외부 서비스 클라이언트 주입
-    // private final OrderFeignClient orderClient;
+     private final OrderFeignClient orderClient;
 
-    /**
-     * 주문 존재 여부 검증
-     */
+    // 주문 존재 여부 검증
     @Override
     public void validateOrderExists(UUID orderId) {
-        // TODO: Order Service 연동
-        // OrderResponse response = orderClient.getOrder(orderId);
-        // FIXME: 임시 하드코딩
-        OrderResponse response = OrderResponse.of(
-                orderId,
-                UUID.fromString("11111111-1111-1111-1111-111111111111"),
-                UUID.fromString("22222222-2222-2222-2222-222222222222")
-        );
+        OrderResponse response = orderClient.getOrder(orderId).data();
         response.validate();
-
-        log.debug("[Order] 주문 존재 확인 완료. orderId: {}, supplierCompanyId: {}, customerCompanyId: {}",
-                response.orderId(), response.supplierCompanyId(), response.customerCompanyId());
-
-        log.warn("[TODO] Order Service 연동 필요 - 임시 하드코딩 응답 반환");
+        log.debug("[OrderClient] 주문 존재 확인 완료. orderId: {}", response.orderId());
     }
 }

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/infrastructure/client/OrderFeignClient.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/infrastructure/client/OrderFeignClient.java
@@ -1,5 +1,6 @@
 package com.luckylogistics.delivery.infrastructure.client;
 
+import com.luckylogistics.delivery.common.response.ApiResponse;
 import com.luckylogistics.delivery.infrastructure.client.dto.OrderResponse;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -7,9 +8,9 @@ import org.springframework.web.bind.annotation.PathVariable;
 
 import java.util.UUID;
 
-@FeignClient(name = "order")
+@FeignClient(name = "order", path = "/api/v1/orders")
 public interface OrderFeignClient {
 
-    @GetMapping("/api/v1/orders/{orderId}")
-    OrderResponse getOrder(@PathVariable("orderId") UUID orderId);
+    @GetMapping("/{orderId}")
+    ApiResponse<OrderResponse> getOrder(@PathVariable("orderId") UUID orderId);
 }

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/infrastructure/client/UseFeignClient.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/infrastructure/client/UseFeignClient.java
@@ -1,14 +1,14 @@
 package com.luckylogistics.delivery.infrastructure.client;
 
+import com.luckylogistics.delivery.common.response.ApiResponse;
 import com.luckylogistics.delivery.infrastructure.client.dto.UserResponse;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 
-// TODO: User Service 연동
-@FeignClient(name = "user")
+@FeignClient(name = "user", path = "/api/v1/users")
 public interface UseFeignClient {
 
-    @GetMapping("/api/v1/users/{userId}")
-    UserResponse getUser(@PathVariable("userId") Long userId);
+    @GetMapping("/{userId}")
+    ApiResponse<UserResponse> getUser(@PathVariable("userId") Long userId);
 }

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/infrastructure/client/UserAdapter.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/infrastructure/client/UserAdapter.java
@@ -1,6 +1,7 @@
 package com.luckylogistics.delivery.infrastructure.client;
 
 import com.luckylogistics.delivery.application.service.UserService;
+import com.luckylogistics.delivery.infrastructure.client.dto.UserResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -9,19 +10,15 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 public class UserAdapter implements UserService {
-    // TODO: 외부 서비스 클라이언트 주입
-    // private final UseFeignClient userClient;
 
-    /**
-     * 배송 담당자 권한 검증
-     */
-    public void validateDeliveryManagerRole(Long userId) {
-        // TODO: User Service 연동
-        // UserResponse user = userClient.getUser(userId);
-        // if (user.role() != UserRole.DELIVERY_MANAGER) {
-        //     throw new BusinessException(ErrorCode.INVALID_USER_ROLE);
-        // }
+     private final UseFeignClient userClient;
 
-        log.warn("[TODO] User Service 연동 필요 - userId 검증 생략: {}", userId);
+    // 배송 담당자 권한 검증
+    @Override
+    public void validateUserIsDeliveryManager(Long userId) {
+        UserResponse response = userClient.getUser(userId).data();
+        response.validate();
+        response.validateDeliveryManagerRole();
+        log.debug("[UserClient] 배송 담당자 권한 검증 완료. userId={}, role={}", userId, response.role());
     }
 }

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/infrastructure/client/dto/HubResponse.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/infrastructure/client/dto/HubResponse.java
@@ -1,15 +1,18 @@
 package com.luckylogistics.delivery.infrastructure.client.dto;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
-// TODO: Hub Service 연동
 public record HubResponse(
         UUID hubId,
         String name,
         String address,
         Double latitude,
-        Double longitude
+        Double longitude,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
 ) {
+    // 응답 데이터 유효성 검증
     public void validate() {
         if (hubId == null) {
             throw new IllegalStateException("[HubClient] hubId가 유효하지 않습니다");

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/infrastructure/client/dto/HubRoutePlanResponse.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/infrastructure/client/dto/HubRoutePlanResponse.java
@@ -35,7 +35,7 @@ public record HubRoutePlanResponse(
 
     public void validate() {
         if (routes.isEmpty())
-            throw new IllegalArgumentException("[HubClient] routes는 비어 있을 수 없습니다.");
+            throw new IllegalArgumentException("[HubClient] routes가 유효하지 않습니다.");
 
         if (totalDistance == null || totalDistance.compareTo(BigDecimal.ZERO) <= 0)
             throw new IllegalArgumentException("[HubClient] totalDistance는 0보다 커야 합니다.");

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/infrastructure/client/dto/HubRouteResponse.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/infrastructure/client/dto/HubRouteResponse.java
@@ -5,7 +5,6 @@ import lombok.Builder;
 import java.math.BigDecimal;
 import java.util.UUID;
 
-// TODO: Hub Service 연동
 @Builder
 public record HubRouteResponse(
         Integer sequence,
@@ -37,10 +36,10 @@ public record HubRouteResponse(
             throw new IllegalArgumentException("[HubClient] 경로 sequence는 1 이상의 값이어야 합니다.");
 
         if (departureHubId == null)
-            throw new IllegalArgumentException("[HubClient] 출발 hubId는 필수입니다.");
+            throw new IllegalArgumentException("[HubClient] departureHubId가 유효하지 않습니다.");
 
         if (arrivalHubId == null)
-            throw new IllegalArgumentException("[HubClient] 도착 hubId는 필수입니다.");
+            throw new IllegalArgumentException("[HubClient] arrivalHubId가 유효하지 않습니다");
 
         if (distanceKm == null || distanceKm.compareTo(BigDecimal.ZERO) <= 0)
             throw new IllegalArgumentException("[HubClient] distanceKm은 0보다 커야 합니다.");

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/infrastructure/client/dto/OrderResponse.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/infrastructure/client/dto/OrderResponse.java
@@ -1,36 +1,39 @@
 package com.luckylogistics.delivery.infrastructure.client.dto;
 
+import com.luckylogistics.delivery.common.enums.OrderStatus;
 import lombok.Builder;
 
 import java.util.UUID;
 
-// TODO: Order Service 연동
 @Builder
 public record OrderResponse(
-        UUID orderId,             // 주문 ID
-        UUID supplierCompanyId,   // 공급업체 ID
-        UUID customerCompanyId    // 수령업체 ID
+        UUID orderId,
+        int quantity,
+        String request,
+        OrderStatus status,
+        UUID supplierId,
+        UUID customerId,
+        UUID productId,
+        UUID deliveryId
 ) {
-    /**
-     * 응답 데이터 유효성 검증
-     */
+    // 응답 데이터 유효성 검증
     public void validate() {
         if (orderId == null) {
             throw new IllegalStateException("[OrderClient] orderId가 유효하지 않습니다");
         }
-        if (supplierCompanyId == null) {
-            throw new IllegalStateException("[OrderClient] supplierCompanyId가 유효하지 않습니다");
+        if (supplierId == null) {
+            throw new IllegalStateException("[OrderClient] supplierId가 유효하지 않습니다");
         }
-        if (customerCompanyId == null) {
-            throw new IllegalStateException("[OrderClient] customerCompanyId가 유효하지 않습니다");
+        if (customerId == null) {
+            throw new IllegalStateException("[OrderClient] customerId가 유효하지 않습니다");
         }
     }
 
     public static OrderResponse of(UUID orderId, UUID supplierCompanyId, UUID customerCompanyId) {
         return OrderResponse.builder()
                 .orderId(orderId)
-                .supplierCompanyId(supplierCompanyId)
-                .customerCompanyId(customerCompanyId)
+                .supplierId(supplierCompanyId)
+                .customerId(customerCompanyId)
                 .build();
     }
 }

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/infrastructure/client/dto/UserResponse.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/infrastructure/client/dto/UserResponse.java
@@ -1,10 +1,43 @@
 package com.luckylogistics.delivery.infrastructure.client.dto;
 
+import com.luckylogistics.delivery.common.enums.UserOrganizationType;
 import com.luckylogistics.delivery.common.enums.UserRole;
+import com.luckylogistics.delivery.common.enums.UserStatus;
+import lombok.Builder;
 
-// TODO: User Service 연동
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Builder
 public record UserResponse(
-        Long userId,
-        UserRole role
+        UUID identifier,
+        String username,
+        String slackId,
+        UserRole role,
+        UserOrganizationType organizationType, // HUB, COMPANY
+        UUID organizationId,
+        UserStatus status,
+        boolean deleted,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
 ) {
+    // 응답 데이터 유효성 검증
+    public void validate() {
+        if (identifier == null) {
+            throw new IllegalStateException("[UserClient] identifier가 유효하지 않습니다");
+        }
+        if (role == null) {
+            throw new IllegalStateException("[UserClient] role이 유효하지 않습니다");
+        }
+        if (organizationType == null || organizationId == null) {
+            throw new IllegalStateException("[UserClient] organization 정보가 유효하지 않습니다");
+        }
+    }
+
+    // 사용자 권한 검증 - 배송 담당자 여부 확인
+    public void validateDeliveryManagerRole() {
+        if (role == null || !role.isDeliveryManager()) {
+            throw new IllegalStateException("[UserClient] 배송 담당자 권한이 아닙니다");
+        }
+    }
 }

--- a/delivery/delivery/src/main/java/com/luckylogistics/delivery/infrastructure/configuration/FeignClientConfig.java
+++ b/delivery/delivery/src/main/java/com/luckylogistics/delivery/infrastructure/configuration/FeignClientConfig.java
@@ -1,0 +1,42 @@
+package com.luckylogistics.delivery.infrastructure.configuration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import feign.RequestInterceptor;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@Configuration
+public class FeignClientConfig {
+
+    @Bean
+    public RequestInterceptor requestInterceptor() {
+        return template -> {
+            RequestAttributes requestAttributes = RequestContextHolder.getRequestAttributes();
+
+            if (requestAttributes != null) {
+                HttpServletRequest request = ((ServletRequestAttributes)requestAttributes).getRequest();
+
+                String token = request.getHeader("Authorization");
+                if (token != null && !token.isEmpty()) {
+                    template.header(HttpHeaders.AUTHORIZATION, token);
+                }
+            }
+        };
+    }
+
+    @Bean
+    public feign.codec.Decoder customDecoder(ObjectMapper objectMapper) {
+        return (response, type) -> {
+            try (var reader = response.body().asReader()) {
+                // 제네릭 타입 (ApiResponse<Response>) 파싱 가능하게 처리
+                return objectMapper.readValue(reader, objectMapper.constructType(type));
+            }
+        };
+    }
+
+}

--- a/delivery/delivery/src/main/resources/application.yml
+++ b/delivery/delivery/src/main/resources/application.yml
@@ -8,5 +8,5 @@ spring:
   profiles:
     include:
       - datasource
-#      - eureka
-#      - zipkin
+      - eureka
+      - zipkin


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩터링
- [ ] 환경 설정/빌드
- [ ] 기타

## ❗️ 관련 이슈 링크
Close #49 

## 📝 개요
- Delivery 도메인 전반에 FeignClient 구조를 적용하여 외부 서비스(User, Order, Hub)와의 연동 기능을 추가했습니다.
- Eureka 기반 서비스 디스커버리, Authorization 헤더 전파, 공통 응답 파싱 등 통신 환경 구성을 완료했습니다.

## 🔁 변경 사항
- Delivery 도메인 전반에 FeignClient 적용
- User / Order / Hub 서비스 연동 기능 추가
- Feign 예외 처리 및 공통 에러 코드(`FEIGN_ERROR`) 추가
- Authorization 헤더 전파 및 `ApiResponse` 파싱 설정 추가
- Eureka 클라이언트 등록 및 서비스 디스커버리 활성화

## 👀 참고 사항
- 각 외부 서비스 호출 시 `ApiResponse<T>` 기반으로 응답 파싱됨
- Feign 예외 발생 시 `FEIGN_ERROR` 코드로 일관된 응답 반환
- 각 담당자께서는 연동된 서비스 API URL이 정확한지 확인 부탁드립니다.
  - User: @yeana07
  - Order: @rollingball211
  - Hub: @Hongssi96

## 👀 기타
- Zipkin으로 Feign 트레이싱 확인 가능